### PR TITLE
Handle invalid input for format_distance

### DIFF
--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -122,11 +122,19 @@ def format_duration(minutes: int) -> str:
 
 def format_distance(meters: float) -> str:
     """Format distance in meters to human readable string."""
+    try:
+        meters = float(meters)
+    except (TypeError, ValueError):
+        return "0m"
+
+    if meters < 0:
+        meters = 0
+
     if meters < 1000:
         return f"{int(meters)}m"
-    else:
-        km = meters / 1000
-        return f"{km:.1f}km"
+
+    km = meters / 1000
+    return f"{km:.1f}km"
 
 
 def format_weight(kg: float) -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,10 @@ import pytest
 # Ensure custom component package is importable
 sys.path.insert(0, os.path.abspath('.'))
 
-from custom_components.pawcontrol.utils import calculate_dog_calories_per_day
+from custom_components.pawcontrol.utils import (
+    calculate_dog_calories_per_day,
+    format_distance,
+)
 
 
 def test_calculate_dog_calories_positive():
@@ -17,3 +20,11 @@ def test_calculate_dog_calories_invalid_weight():
     """Invalid or negative weights should return 0 calories instead of raising errors."""
     assert calculate_dog_calories_per_day(-5) == 0
     assert calculate_dog_calories_per_day("bad") == 0
+
+
+def test_format_distance_handles_various_inputs():
+    """Distances should be formatted and invalid values handled gracefully."""
+    assert format_distance(500) == "500m"
+    assert format_distance(1500) == "1.5km"
+    assert format_distance(-100) == "0m"
+    assert format_distance("oops") == "0m"


### PR DESCRIPTION
## Summary
- validate input in `format_distance` to avoid type errors and negative values
- test `format_distance` with valid, negative, and invalid inputs

## Testing
- `pytest -q -o addopts="" -o filterwarnings="default"`


------
https://chatgpt.com/codex/tasks/task_e_688f787bbc18833187524a118dc1b33b