### PR TITLE
Fix distance formatting for whole kilometers

### DIFF
--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -134,6 +134,11 @@ def format_distance(meters: float) -> str:
         return f"{int(meters)}m"
 
     km = meters / 1000
+
+    # Avoid showing trailing .0 for whole kilometers (e.g., 1000 -> "1km")
+    if float(km).is_integer():
+        return f"{int(km)}km"
+
     return f"{km:.1f}km"
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,5 +26,6 @@ def test_format_distance_handles_various_inputs():
     """Distances should be formatted and invalid values handled gracefully."""
     assert format_distance(500) == "500m"
     assert format_distance(1500) == "1.5km"
+    assert format_distance(1000) == "1km"
     assert format_distance(-100) == "0m"
     assert format_distance("oops") == "0m"


### PR DESCRIPTION
## Summary
- avoid trailing `.0` in `format_distance` when distance is an exact number of kilometers
- expand distance formatting tests to cover whole kilometer case

## Testing
- `pytest -q -c /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_688f7a0f68788331902ac88260cf403a