### PR TITLE
Improve duration formatting resilience

### DIFF
--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -108,17 +108,22 @@ def calculate_distance(coord1: Tuple[float, float], coord2: Tuple[float, float])
 
 
 def format_duration(minutes: int) -> str:
-    """Format duration in minutes to human readable string."""
+    """Format duration in minutes to a human readable string."""
+    if not isinstance(minutes, int):
+        return "0 min"
+
+    if minutes <= 0:
+        return "0 min"
+
     if minutes < 60:
         return f"{minutes} min"
-    
+
     hours = minutes // 60
     remaining_minutes = minutes % 60
-    
+
     if remaining_minutes == 0:
         return f"{hours}h"
-    else:
-        return f"{hours}h {remaining_minutes}min"
+    return f"{hours}h {remaining_minutes}min"
 
 
 def format_distance(meters: float) -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ sys.path.insert(0, os.path.abspath('.'))
 from custom_components.pawcontrol.utils import (
     calculate_dog_calories_per_day,
     format_distance,
+    format_duration,
 )
 
 
@@ -29,3 +30,24 @@ def test_format_distance_handles_various_inputs():
     assert format_distance(1000) == "1km"
     assert format_distance(-100) == "0m"
     assert format_distance("oops") == "0m"
+
+
+@pytest.mark.parametrize("value", [None, "10", 5.5, -1, 0])
+def test_format_duration_invalid_types_and_values(value):
+    """Invalid types or non-positive durations should return '0 min'."""
+    assert format_duration(value) == "0 min"
+
+
+def test_format_duration_under_an_hour():
+    """Durations under an hour should be shown in minutes."""
+    assert format_duration(45) == "45 min"
+
+
+def test_format_duration_exact_hours():
+    """Exact multiples of an hour should omit minutes."""
+    assert format_duration(120) == "2h"
+
+
+def test_format_duration_hours_and_minutes():
+    """Durations with remaining minutes should show hours and minutes."""
+    assert format_duration(125) == "2h 5min"


### PR DESCRIPTION
## Summary
- Handle invalid and negative duration inputs gracefully
- Test `format_duration` for invalid, zero, and mixed hour inputs

## Testing
- `pytest tests/test_utils.py -q -c /tmp/pytest.ini`


------
https://chatgpt.com/codex/tasks/task_e_688f7e9fbf308331ae49624bd4c36cd2