### PR TITLE
Handle invalid weights gracefully

### DIFF
--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -150,7 +150,19 @@ def format_distance(meters: float) -> str:
 
 
 def format_weight(kg: float) -> str:
-    """Format weight to human readable string."""
+    """Format weight to a human readable string.
+
+    Ensures invalid, non-numeric or negative values are handled gracefully
+    instead of raising errors or returning misleading results.
+    """
+    try:
+        kg = float(kg)
+    except (TypeError, ValueError):
+        return "0.0kg"
+
+    if not isfinite(kg) or kg < 0:
+        kg = 0.0
+
     return f"{kg:.1f}kg"
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,14 +1,16 @@
 import os
 import sys
+
 import pytest
 
 # Ensure custom component package is importable
-sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath("."))
 
 from custom_components.pawcontrol.utils import (
     calculate_dog_calories_per_day,
     format_distance,
     format_duration,
+    format_weight,
 )
 
 
@@ -30,6 +32,13 @@ def test_format_distance_handles_various_inputs():
     assert format_distance(1000) == "1km"
     assert format_distance(-100) == "0m"
     assert format_distance("oops") == "0m"
+
+
+def test_format_weight_handles_various_inputs():
+    """Weights should be formatted and invalid values handled gracefully."""
+    assert format_weight(10) == "10.0kg"
+    assert format_weight("bad") == "0.0kg"
+    assert format_weight(-5) == "0.0kg"
 
 
 @pytest.mark.parametrize("value", [None, "10", 5.5, -1, 0])


### PR DESCRIPTION
## Summary
- handle invalid weight values in util function
- add unit tests for weight formatting

## Testing
- `pytest -c /dev/null`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688f8ad9c18483319dbe3df51be1cdf7