### PR TITLE
Handle datetime inputs in time_since_last_activity

### DIFF
--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -323,13 +323,21 @@ def estimate_calories_burned(distance_km: float, weight_kg: float, activity_inte
     return max(1, int(calories))
 
 
-def time_since_last_activity(last_activity_time: str) -> timedelta:
-    """Calculate time since last activity."""
+def time_since_last_activity(last_activity_time: str | datetime) -> timedelta:
+    """Calculate time since last activity.
+
+    Accepts ISO formatted strings or ``datetime`` objects. Any parsing errors
+    result in a large ``timedelta`` so callers can treat unknown values
+    consistently.
+    """
     try:
         if not last_activity_time or last_activity_time in ["unknown", "unavailable"]:
             return timedelta(days=999)  # Very long time if unknown
 
-        last_time = datetime.fromisoformat(last_activity_time.replace("Z", "+00:00"))
+        if isinstance(last_activity_time, datetime):
+            last_time = last_activity_time
+        else:
+            last_time = datetime.fromisoformat(str(last_activity_time).replace("Z", "+00:00"))
 
         if last_time.tzinfo:
             now = datetime.now(timezone.utc)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -87,3 +87,13 @@ def test_time_since_last_activity_handles_naive_and_aware():
     offset_result = time_since_last_activity(past_offset.isoformat())
     expected_offset = datetime.now(tz) - past_offset
     assert abs(offset_result - expected_offset) <= tolerance
+
+
+def test_time_since_last_activity_accepts_datetime_object():
+    """Datetime objects should be handled directly without requiring conversion."""
+    tolerance = timedelta(seconds=1)
+    past_time = datetime.now() - timedelta(minutes=5)
+    result = time_since_last_activity(past_time)
+    expected = datetime.now() - past_time
+    assert isinstance(result, timedelta)
+    assert abs(result - expected) <= tolerance


### PR DESCRIPTION
## Summary
- allow `time_since_last_activity` to accept `datetime` objects alongside ISO strings
- add regression test ensuring direct `datetime` inputs are processed correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688faacdad208331b6cc97337764a690