### PR TITLE
refactor: modular module loading

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -2,15 +2,12 @@
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from . import dashboard, gps, health, push, walk
+from . import dashboard
 from .const import (
     CONF_CREATE_DASHBOARD,
     CONF_DOG_NAME,
-    CONF_GPS_ENABLE,
-    CONF_HEALTH_MODULE,
-    CONF_NOTIFICATIONS_ENABLED,
-    CONF_WALK_MODULE,
 )
+from .module_registry import MODULES
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
@@ -21,25 +18,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     await ensure_helpers(hass, opts)
 
     # 2. Modul-Setup je nach Opt-in/Opt-out
-    if opts.get(CONF_GPS_ENABLE, True):
-        await gps.setup_gps(hass, entry)
-    else:
-        await gps.teardown_gps(hass, entry)
-
-    if opts.get(CONF_NOTIFICATIONS_ENABLED, True):
-        await push.setup_push(hass, entry)
-    else:
-        await push.teardown_push(hass, entry)
-
-    if opts.get(CONF_HEALTH_MODULE, True):
-        await health.setup_health(hass, entry)
-    else:
-        await health.teardown_health(hass, entry)
-
-    if opts.get(CONF_WALK_MODULE, True):
-        await walk.setup_walk(hass, entry)
-    else:
-        await walk.teardown_walk(hass, entry)
+    for key, module in MODULES.items():
+        if opts.get(key, module.default):
+            await module.setup(hass, entry)
+        elif module.teardown:
+            await module.teardown(hass, entry)
 
     if opts.get(CONF_CREATE_DASHBOARD, False):
         await dashboard.create_dashboard(hass, opts[CONF_DOG_NAME])
@@ -48,10 +31,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
 async def async_unload_entry(hass, entry):
     """Beim Entfernen der Integration: alle Module/Helper aufräumen."""
-    await gps.teardown_gps(hass, entry)
-    await push.teardown_push(hass, entry)
-    await health.teardown_health(hass, entry)
-    await walk.teardown_walk(hass, entry)
+    for module in MODULES.values():
+        if module.teardown:
+            await module.teardown(hass, entry)
     # Dashboard bleibt, falls es nicht explizit entfernt werden soll.
     return True
 
@@ -59,10 +41,7 @@ async def ensure_helpers(hass, opts):
     """Prüft und legt alle für aktivierte Module nötigen Helper/Sensoren an."""
     # Beispiel: Health-Status, Walk-Counter, GPS-Status, ...
     # (Diese Logik ruft die Helper-Init der jeweiligen Module auf.)
-    if opts.get(CONF_HEALTH_MODULE, True):
-        await health.ensure_helpers(hass, opts)
-    if opts.get(CONF_WALK_MODULE, True):
-        await walk.ensure_helpers(hass, opts)
-    if opts.get(CONF_GPS_ENABLE, True):
-        await gps.ensure_helpers(hass, opts)
+    for key, module in MODULES.items():
+        if opts.get(key, module.default) and module.ensure_helpers:
+            await module.ensure_helpers(hass, opts)
     # Usw. für weitere Module

--- a/custom_components/pawcontrol/config_flow.py
+++ b/custom_components/pawcontrol/config_flow.py
@@ -1,6 +1,7 @@
 import voluptuous as vol
 from homeassistant import config_entries
 from .const import *
+from .module_registry import MODULES
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle config flow for Paw Control."""
@@ -10,24 +11,23 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             # Hier können Validierungen ergänzt werden!
             return self.async_create_entry(title=user_input[CONF_DOG_NAME], data=user_input)
+        schema = {
+            vol.Required(CONF_DOG_NAME): str,
+            vol.Optional(CONF_DOG_BREED, default=""): str,
+            vol.Optional(CONF_DOG_AGE, default=0): int,
+            vol.Optional(CONF_DOG_WEIGHT, default=0.0): float,
+            vol.Optional(CONF_FEEDING_TIMES, default=DEFAULT_FEEDING_TIMES): list,
+            vol.Optional(CONF_WALK_DURATION, default=DEFAULT_WALK_DURATION): int,
+            vol.Optional(CONF_VET_CONTACT, default=""): str,
+        }
+        for key, module in MODULES.items():
+            schema[vol.Optional(key, default=module.default)] = bool
+        schema[vol.Optional(CONF_CREATE_DASHBOARD, default=False)] = bool
+
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema({
-                vol.Required(CONF_DOG_NAME): str,
-                vol.Optional(CONF_DOG_BREED, default=""): str,
-                vol.Optional(CONF_DOG_AGE, default=0): int,
-                vol.Optional(CONF_DOG_WEIGHT, default=0.0): float,
-                vol.Optional(CONF_FEEDING_TIMES, default=DEFAULT_FEEDING_TIMES): list,
-                vol.Optional(CONF_WALK_DURATION, default=DEFAULT_WALK_DURATION): int,
-                vol.Optional(CONF_VET_CONTACT, default=""): str,
-                # Modul-Toggles
-                vol.Optional(CONF_GPS_ENABLE, default=True): bool,
-                vol.Optional(CONF_NOTIFICATIONS_ENABLED, default=True): bool,
-                vol.Optional(CONF_HEALTH_MODULE, default=True): bool,
-                vol.Optional(CONF_WALK_MODULE, default=True): bool,
-                vol.Optional(CONF_CREATE_DASHBOARD, default=False): bool,
-            }),
-            errors=errors
+            data_schema=vol.Schema(schema),
+            errors=errors,
         )
 
     async def async_step_options(self, user_input=None):
@@ -35,13 +35,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         data = entry.data
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
+        schema = {}
+        for key, module in MODULES.items():
+            schema[vol.Optional(key, default=data.get(key, module.default))] = bool
+        schema[vol.Optional(CONF_CREATE_DASHBOARD, default=data.get(CONF_CREATE_DASHBOARD, False))] = bool
+
         return self.async_show_form(
             step_id="options",
-            data_schema=vol.Schema({
-                vol.Optional(CONF_GPS_ENABLE, default=data.get(CONF_GPS_ENABLE, True)): bool,
-                vol.Optional(CONF_NOTIFICATIONS_ENABLED, default=data.get(CONF_NOTIFICATIONS_ENABLED, True)): bool,
-                vol.Optional(CONF_HEALTH_MODULE, default=data.get(CONF_HEALTH_MODULE, True)): bool,
-                vol.Optional(CONF_WALK_MODULE, default=data.get(CONF_WALK_MODULE, True)): bool,
-                vol.Optional(CONF_CREATE_DASHBOARD, default=data.get(CONF_CREATE_DASHBOARD, False)): bool,
-            }),
+            data_schema=vol.Schema(schema),
         )

--- a/custom_components/pawcontrol/module_registry.py
+++ b/custom_components/pawcontrol/module_registry.py
@@ -1,0 +1,58 @@
+"""Registry for optional Paw Control modules."""
+from __future__ import annotations
+
+from typing import Awaitable, Callable, Dict, Optional
+
+from .const import (
+    CONF_GPS_ENABLE,
+    CONF_NOTIFICATIONS_ENABLED,
+    CONF_HEALTH_MODULE,
+    CONF_WALK_MODULE,
+)
+
+from . import gps, push, health, walk
+
+ModuleFunc = Callable[..., Awaitable[None]]
+
+
+class Module:
+    """Container for module handlers."""
+
+    def __init__(
+        self,
+        setup: ModuleFunc,
+        teardown: Optional[ModuleFunc] = None,
+        ensure_helpers: Optional[ModuleFunc] = None,
+        default: bool = True,
+    ) -> None:
+        self.setup = setup
+        self.teardown = teardown
+        self.ensure_helpers = ensure_helpers
+        self.default = default
+
+
+MODULES: Dict[str, Module] = {
+    CONF_GPS_ENABLE: Module(
+        setup=gps.setup_gps,
+        teardown=gps.teardown_gps,
+        ensure_helpers=gps.ensure_helpers,
+        default=True,
+    ),
+    CONF_NOTIFICATIONS_ENABLED: Module(
+        setup=push.setup_push,
+        teardown=push.teardown_push,
+        default=True,
+    ),
+    CONF_HEALTH_MODULE: Module(
+        setup=health.setup_health,
+        teardown=health.teardown_health,
+        ensure_helpers=health.ensure_helpers,
+        default=True,
+    ),
+    CONF_WALK_MODULE: Module(
+        setup=walk.setup_walk,
+        teardown=walk.teardown_walk,
+        ensure_helpers=walk.ensure_helpers,
+        default=True,
+    ),
+}

--- a/tests/test_module_registry.py
+++ b/tests/test_module_registry.py
@@ -1,0 +1,77 @@
+import os
+import sys
+
+import pytest
+from unittest.mock import AsyncMock, patch
+from types import SimpleNamespace
+
+# Ensure the custom component package is importable
+sys.path.insert(0, os.path.abspath("."))
+
+from custom_components.pawcontrol import config_flow
+import custom_components.pawcontrol as integration
+from custom_components.pawcontrol.const import DOMAIN, CONF_DOG_NAME
+from custom_components.pawcontrol import module_registry
+from homeassistant import config_entries
+
+
+@pytest.mark.parametrize('module_key', list(module_registry.MODULES.keys()))
+def test_module_enable_disable(monkeypatch, module_key):
+    async def run_test():
+        patched = {}
+        for key, mod in module_registry.MODULES.items():
+            setup_mock = AsyncMock()
+            teardown_mock = AsyncMock()
+            helper_mock = AsyncMock()
+            monkeypatch.setattr(mod, 'setup', setup_mock)
+            monkeypatch.setattr(mod, 'teardown', teardown_mock)
+            monkeypatch.setattr(mod, 'ensure_helpers', helper_mock)
+            patched[key] = (setup_mock, teardown_mock, helper_mock)
+
+        user_input = {CONF_DOG_NAME: 'Fido'}
+        for key in module_registry.MODULES.keys():
+            user_input[key] = (key == module_key)
+
+        flow = config_flow.ConfigFlow()
+        flow.hass = SimpleNamespace()
+        with patch.object(config_flow.ConfigFlow, 'async_create_entry', return_value={'data': user_input}):
+            result = await flow.async_step_user(user_input)
+
+        entry = config_entries.ConfigEntry(
+            version=1,
+            minor_version=1,
+            domain=DOMAIN,
+            title='Fido',
+            data=result['data'],
+            source='user',
+        )
+
+        hass = SimpleNamespace(config_entries=SimpleNamespace(async_entries=lambda domain: [entry]))
+
+        await integration.async_setup_entry(hass, entry)
+
+        setup_mock, teardown_mock, helper_mock = patched[module_key]
+        setup_mock.assert_called_once_with(hass, entry)
+        helper_mock.assert_called_once_with(hass, result['data'])
+        teardown_mock.assert_not_called()
+
+        setup_mock.reset_mock()
+        teardown_mock.reset_mock()
+        helper_mock.reset_mock()
+
+        options_input = {key: False for key in module_registry.MODULES.keys()}
+        flow2 = config_flow.ConfigFlow()
+        flow2.hass = hass
+        with patch.object(config_flow.ConfigFlow, 'async_create_entry', return_value={'data': options_input}):
+            result2 = await flow2.async_step_options(options_input)
+
+        entry.options = result2['data']
+
+        await integration.async_setup_entry(hass, entry)
+
+        setup_mock.assert_not_called()
+        helper_mock.assert_not_called()
+        teardown_mock.assert_called_once_with(hass, entry)
+
+    import asyncio
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- centralize optional module definitions and handlers
- drive setup/unload and helper creation via registry
- build config flow options dynamically from registered modules
- add tests ensuring each module's enable/disable triggers proper setup, teardown, and helpers

## Testing
- `pytest -q`
- `python -m py_compile custom_components/pawcontrol/module_registry.py custom_components/pawcontrol/__init__.py custom_components/pawcontrol/config_flow.py`


------
https://chatgpt.com/codex/tasks/task_e_688fb242b6d88331a49d6c7758c6d5c4