### PR TITLE
feat: add options flow for modular setup

### DIFF
--- a/custom_components/pawcontrol/config_flow.py
+++ b/custom_components/pawcontrol/config_flow.py
@@ -1,16 +1,21 @@
+"""Config flow for Paw Control with dynamic module options."""
+
 import voluptuous as vol
 from homeassistant import config_entries
+from homeassistant.core import callback
+
 from .const import *
 from .module_registry import MODULES
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Handle config flow for Paw Control."""
+    """Handle initial configuration for Paw Control."""
 
     async def async_step_user(self, user_input=None):
         errors = {}
         if user_input is not None:
             # Hier können Validierungen ergänzt werden!
             return self.async_create_entry(title=user_input[CONF_DOG_NAME], data=user_input)
+
         schema = {
             vol.Required(CONF_DOG_NAME): str,
             vol.Optional(CONF_DOG_BREED, default=""): str,
@@ -30,17 +35,28 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    async def async_step_options(self, user_input=None):
-        entry = self.hass.config_entries.async_entries(DOMAIN)[0]
-        data = entry.data
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Return the options flow handler."""
+        return OptionsFlowHandler(config_entry)
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle option flow for Paw Control to enable/disable modules."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):  # pragma: no cover - HA handles step name
+        data = self.config_entry.options or self.config_entry.data
+
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
+
         schema = {}
         for key, module in MODULES.items():
             schema[vol.Optional(key, default=data.get(key, module.default))] = bool
         schema[vol.Optional(CONF_CREATE_DASHBOARD, default=data.get(CONF_CREATE_DASHBOARD, False))] = bool
 
-        return self.async_show_form(
-            step_id="options",
-            data_schema=vol.Schema(schema),
-        )
+        return self.async_show_form(step_id="init", data_schema=vol.Schema(schema))

--- a/tests/test_module_registry.py
+++ b/tests/test_module_registry.py
@@ -60,10 +60,10 @@ def test_module_enable_disable(monkeypatch, module_key):
         helper_mock.reset_mock()
 
         options_input = {key: False for key in module_registry.MODULES.keys()}
-        flow2 = config_flow.ConfigFlow()
-        flow2.hass = hass
-        with patch.object(config_flow.ConfigFlow, 'async_create_entry', return_value={'data': options_input}):
-            result2 = await flow2.async_step_options(options_input)
+        options_flow = config_flow.OptionsFlowHandler(entry)
+        options_flow.hass = hass
+        with patch.object(config_flow.OptionsFlowHandler, 'async_create_entry', return_value={'data': options_input}):
+            result2 = await options_flow.async_step_init(options_input)
 
         entry.options = result2['data']
 


### PR DESCRIPTION
## Summary
- enable dynamic module toggling through options flow
- adjust module registry test for new flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688fbef05ce8833196a7de6498ab33bb