### PR TITLE
feat: add options flow for modular setup

### DIFF
--- a/custom_components/pawcontrol/README.md
+++ b/custom_components/pawcontrol/README.md
@@ -21,7 +21,15 @@
 2. Starte Home Assistant neu.
 3. Füge die Integration über die UI hinzu („Paw Control“).
 4. Wähle bei der Einrichtung aus, welche Module du nutzen möchtest.
-5. Später kannst du über die Optionen der Integration jedes Modul aktivieren/deaktivieren.
+5. Über die **Optionen** der Integration kannst du später jedes Modul aktivieren oder deaktivieren.
+
+### Module steuern
+
+Während der Einrichtung und im Optionsdialog werden alle verfügbaren Module als Schalter angezeigt. Ein aktivierter Schalter richtet die zugehörigen Sensoren, Helper und Automationen ein; beim Deaktivieren werden sie wieder entfernt.
+
+![Options Flow mit Modul-Schaltern](images/options_flow.svg)
+
+Die Module lassen sich jederzeit über `Einstellungen → Geräte & Dienste → Paw Control → Optionen` anpassen.
 
 ---
 

--- a/custom_components/pawcontrol/config_flow.py
+++ b/custom_components/pawcontrol/config_flow.py
@@ -1,16 +1,57 @@
+"""Config flow for Paw Control with dynamic module options."""
+
+from typing import Any
+
 import voluptuous as vol
 from homeassistant import config_entries
-from .const import *
+from homeassistant.core import callback
+from homeassistant.data_entry_flow import FlowResult
+
+from .const import (
+    CONF_CREATE_DASHBOARD,
+    CONF_DOG_AGE,
+    CONF_DOG_BREED,
+    CONF_DOG_NAME,
+    CONF_DOG_WEIGHT,
+    CONF_FEEDING_TIMES,
+    CONF_VET_CONTACT,
+    CONF_WALK_DURATION,
+    DEFAULT_FEEDING_TIMES,
+    DEFAULT_WALK_DURATION,
+    DOMAIN,
+)
 from .module_registry import MODULES
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Handle config flow for Paw Control."""
+    """Handle initial configuration for Paw Control."""
 
-    async def async_step_user(self, user_input=None):
-        errors = {}
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the initial step of the config flow.
+
+        The form allows users to enter basic dog information and enables a
+        checkbox for every registered module.  Submitted values are stored in the
+        config entry's data so the integration starts with the selected modules
+        activated.
+
+        Args:
+            user_input: Values provided by the user when the form is submitted,
+                or ``None`` to show the form for the first time.
+
+        Returns:
+            A ``FlowResult`` describing the next step in the flow. This is either
+            a form to be displayed again or an entry creation result when the user
+            has completed the setup.
+        """
+
+        errors: dict[str, str] = {}
         if user_input is not None:
             # Hier können Validierungen ergänzt werden!
-            return self.async_create_entry(title=user_input[CONF_DOG_NAME], data=user_input)
+            return self.async_create_entry(
+                title=user_input[CONF_DOG_NAME], data=user_input
+            )
+
         schema = {
             vol.Required(CONF_DOG_NAME): str,
             vol.Optional(CONF_DOG_BREED, default=""): str,
@@ -30,17 +71,67 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    async def async_step_options(self, user_input=None):
-        entry = self.hass.config_entries.async_entries(DOMAIN)[0]
-        data = entry.data
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Create an options flow handler for an existing config entry.
+
+        Args:
+            config_entry: The configuration entry for which the options flow
+                should be opened.
+
+        Returns:
+            An ``OptionsFlowHandler`` instance that manages the options flow.
+        """
+
+        return OptionsFlowHandler(config_entry)
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle option flow for Paw Control to enable/disable modules."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Store the config entry so existing options can be loaded.
+
+        Args:
+            config_entry: Entry whose options will be edited. Existing options
+                are used as defaults when presenting the form.
+        """
+
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:  # pragma: no cover - HA handles step name
+        """Show and persist module options during configuration.
+
+        When presented without ``user_input`` the method displays a form with a
+        toggle for every known module. Each toggle defaults to the value stored in
+        the existing options or, if never set, the module's predefined default.
+        When ``user_input`` is provided, the chosen values are saved to the config
+        entry so that selections persist across reloads and Home Assistant
+        restarts.
+
+        Args:
+            user_input: Optional mapping of module keys to boolean values when
+                the user submits the form.
+
+        Returns:
+            A ``FlowResult`` that either shows the form again or writes the
+            provided options to the configuration entry.
+        """
+
+        # Use existing options if present so changes persist across restarts
+        data = self.config_entry.options or self.config_entry.data
+
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
+
         schema = {}
         for key, module in MODULES.items():
             schema[vol.Optional(key, default=data.get(key, module.default))] = bool
-        schema[vol.Optional(CONF_CREATE_DASHBOARD, default=data.get(CONF_CREATE_DASHBOARD, False))] = bool
+        schema[vol.Optional(
+            CONF_CREATE_DASHBOARD, default=data.get(CONF_CREATE_DASHBOARD, False)
+        )] = bool
 
-        return self.async_show_form(
-            step_id="options",
-            data_schema=vol.Schema(schema),
-        )
+        return self.async_show_form(step_id="init", data_schema=vol.Schema(schema))

--- a/custom_components/pawcontrol/images/options_flow.svg
+++ b/custom_components/pawcontrol/images/options_flow.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
+  <style>
+    .label { font: 14px sans-serif; }
+    .title { font: bold 16px sans-serif; }
+  </style>
+  <text x="20" y="30" class="title">Options Flow</text>
+  <rect x="20" y="50" width="12" height="12" fill="white" stroke="black" />
+  <text x="23" y="60" class="label">✓</text>
+  <text x="40" y="60" class="label">GPS Tracking</text>
+  <rect x="20" y="80" width="12" height="12" fill="white" stroke="black" />
+  <text x="40" y="90" class="label">Health Module</text>
+  <rect x="20" y="110" width="12" height="12" fill="white" stroke="black" />
+  <text x="23" y="120" class="label">✓</text>
+  <text x="40" y="120" class="label">Walk Module</text>
+  <rect x="20" y="140" width="12" height="12" fill="white" stroke="black" />
+  <text x="40" y="150" class="label">Notifications</text>
+</svg>

--- a/tests/test_module_registry.py
+++ b/tests/test_module_registry.py
@@ -10,7 +10,7 @@ sys.path.insert(0, os.path.abspath("."))
 
 from custom_components.pawcontrol import config_flow
 import custom_components.pawcontrol as integration
-from custom_components.pawcontrol.const import DOMAIN, CONF_DOG_NAME
+from custom_components.pawcontrol.const import DOMAIN, CONF_DOG_NAME, CONF_CREATE_DASHBOARD
 from custom_components.pawcontrol import module_registry
 from homeassistant import config_entries
 
@@ -60,10 +60,10 @@ def test_module_enable_disable(monkeypatch, module_key):
         helper_mock.reset_mock()
 
         options_input = {key: False for key in module_registry.MODULES.keys()}
-        flow2 = config_flow.ConfigFlow()
-        flow2.hass = hass
-        with patch.object(config_flow.ConfigFlow, 'async_create_entry', return_value={'data': options_input}):
-            result2 = await flow2.async_step_options(options_input)
+        options_flow = config_flow.OptionsFlowHandler(entry)
+        options_flow.hass = hass
+        with patch.object(config_flow.OptionsFlowHandler, 'async_create_entry', return_value={'data': options_input}):
+            result2 = await options_flow.async_step_init(options_input)
 
         entry.options = result2['data']
 
@@ -72,6 +72,85 @@ def test_module_enable_disable(monkeypatch, module_key):
         setup_mock.assert_not_called()
         helper_mock.assert_not_called()
         teardown_mock.assert_called_once_with(hass, entry)
+
+        # Re-enable the module through options
+        setup_mock.reset_mock()
+        teardown_mock.reset_mock()
+        helper_mock.reset_mock()
+
+        options_input2 = {key: (key == module_key) for key in module_registry.MODULES.keys()}
+        options_flow2 = config_flow.OptionsFlowHandler(entry)
+        options_flow2.hass = hass
+        with patch.object(config_flow.OptionsFlowHandler, 'async_create_entry', return_value={'data': options_input2}):
+            await options_flow2.async_step_init(options_input2)
+
+        entry.options = options_input2
+
+        await integration.async_setup_entry(hass, entry)
+
+        setup_mock.assert_called_once_with(hass, entry)
+        helper_mock.assert_called_once_with(hass, entry.options)
+        teardown_mock.assert_not_called()
+
+    import asyncio
+    asyncio.run(run_test())
+
+
+def test_options_flow_defaults_and_persistence():
+    """Ensure options flow shows correct defaults and persists selections."""
+
+    async def run_test():
+        data = {CONF_DOG_NAME: "Fido"}
+        for key, mod in module_registry.MODULES.items():
+            data[key] = mod.default
+
+        entry = config_entries.ConfigEntry(
+            version=1,
+            minor_version=1,
+            domain=DOMAIN,
+            title="Fido",
+            data=data,
+            source="user",
+        )
+
+        # options flow defaults come from entry data
+        flow_handler = config_flow.ConfigFlow.async_get_options_flow(entry)
+        assert isinstance(flow_handler, config_flow.OptionsFlowHandler)
+        flow_handler.hass = SimpleNamespace()
+        result = await flow_handler.async_step_init()
+        assert result["type"] == "form" and result["step_id"] == "init"
+        defaults = {
+            opt.schema: opt.default() if callable(opt.default) else opt.default
+            for opt in result["data_schema"].schema.keys()
+        }
+        for key, mod in module_registry.MODULES.items():
+            assert defaults[key] == mod.default
+        assert defaults[CONF_CREATE_DASHBOARD] is False
+
+        # submit new options disabling all modules and enabling dashboard
+        options_input = {key: False for key in module_registry.MODULES.keys()}
+        options_input[CONF_CREATE_DASHBOARD] = True
+        with patch.object(
+            config_flow.OptionsFlowHandler,
+            "async_create_entry",
+            return_value={"data": options_input},
+        ) as create_entry:
+            result2 = await flow_handler.async_step_init(options_input)
+            create_entry.assert_called_once_with(title="", data=options_input)
+
+        entry.options = result2["data"]
+
+        # second run should use options as defaults
+        flow_handler2 = config_flow.OptionsFlowHandler(entry)
+        flow_handler2.hass = SimpleNamespace()
+        result3 = await flow_handler2.async_step_init()
+        defaults2 = {
+            opt.schema: opt.default() if callable(opt.default) else opt.default
+            for opt in result3["data_schema"].schema.keys()
+        }
+        for key in module_registry.MODULES.keys():
+            assert defaults2[key] is False
+        assert defaults2[CONF_CREATE_DASHBOARD] is True
 
     import asyncio
     asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- enable dynamic module toggling through options flow
- adjust module registry test for new flow
- document module toggles and options flow
- expand tests for options flow defaulting and persistence
- add type hints and documentation to flow methods
- clarify docstrings on config and options flow methods

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fbef05ce8833196a7de6498ab33bb