### PR TITLE
Refactor setup flow and installation checks

### DIFF
--- a/custom_components/pawcontrol/config_flow.py
+++ b/custom_components/pawcontrol/config_flow.py
@@ -1,4 +1,12 @@
-"""Config flow for Paw Control with dynamic module options."""
+"""Configuration flow for Paw Control.
+
+This module provides the configuration and options flows for the integration.
+The available modules are defined in :mod:`module_registry` and are presented
+as toggles during installation and in the options flow so the setup is fully
+modular.
+"""
+
+from __future__ import annotations
 
 from typing import Any
 
@@ -6,24 +14,6 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
-from .const import (
-    CONF_CREATE_DASHBOARD,
-    CONF_DOG_AGE,
-    CONF_DOG_BREED,
-    CONF_DOG_NAME,
-    CONF_DOG_WEIGHT,
-    CONF_FEEDING_TIMES,
-    CONF_VET_CONTACT,
-    CONF_WALK_DURATION,
-    DEFAULT_FEEDING_TIMES,
-    DEFAULT_WALK_DURATION,
-    DOMAIN,
-)
-
-import voluptuous as vol
-from homeassistant import config_entries
-from homeassistant.core import callback
-from homeassistant.data_entry_flow import FlowResult
 
 from .const import (
     CONF_CREATE_DASHBOARD,
@@ -38,78 +28,25 @@ from .const import (
     DEFAULT_WALK_DURATION,
     DOMAIN,
 )
-
-import voluptuous as vol
-from homeassistant import config_entries
-from homeassistant.core import callback
-
-from .const import *
-
 from .module_registry import MODULES
 
+
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Handle initial configuration for Paw Control."""
+    """Handle the initial configuration for Paw Control."""
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Handle the initial step of the config flow.
-
-        The form allows users to enter basic dog information and enables a
-        checkbox for every registered module.  Submitted values are stored in the
-        config entry's data so the integration starts with the selected modules
-        activated.
-
-        Args:
-            user_input: Values provided by the user when the form is submitted,
-                or ``None`` to show the form for the first time.
-
-        Returns:
-            A ``FlowResult`` describing the next step in the flow. This is either
-            a form to be displayed again or an entry creation result when the user
-            has completed the setup.
-        """
+        """Handle the first step of the configuration flow."""
 
         errors: dict[str, str] = {}
         if user_input is not None:
-            # Hier können Validierungen ergänzt werden!
+            # Additional validation could be added here
             return self.async_create_entry(
                 title=user_input[CONF_DOG_NAME], data=user_input
             )
 
-
-
-    async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Handle the initial step of the config flow.
-
-        The form allows users to enter basic dog information and enables a
-        checkbox for every registered module.  Submitted values are stored in the
-        config entry's data so the integration starts with the selected modules
-        activated.
-
-        Args:
-            user_input: Values provided by the user when the form is submitted,
-                or ``None`` to show the form for the first time.
-
-        Returns:
-            A ``FlowResult`` describing the next step in the flow. This is either
-            a form to be displayed again or an entry creation result when the user
-            has completed the setup.
-        """
-
-        errors: dict[str, str] = {}
-        if user_input is not None:
-            # Hier können Validierungen ergänzt werden!
-
-            return self.async_create_entry(
-                title=user_input[CONF_DOG_NAME], data=user_input
-            )
-            return self.async_create_entry(title=user_input[CONF_DOG_NAME], data=user_input)
-
-
-        schema = {
+        schema: dict[Any, Any] = {
             vol.Required(CONF_DOG_NAME): str,
             vol.Optional(CONF_DOG_BREED, default=""): str,
             vol.Optional(CONF_DOG_AGE, default=0): int,
@@ -118,6 +55,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Optional(CONF_WALK_DURATION, default=DEFAULT_WALK_DURATION): int,
             vol.Optional(CONF_VET_CONTACT, default=""): str,
         }
+        # Add a toggle for every registered module
         for key, module in MODULES.items():
             schema[vol.Optional(key, default=module.default)] = bool
         schema[vol.Optional(CONF_CREATE_DASHBOARD, default=False)] = bool
@@ -130,78 +68,35 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry):
-        """Create an options flow handler for an existing config entry.
-
-        Args:
-            config_entry: The configuration entry for which the options flow
-                should be opened.
-
-        Args:
-            config_entry: The configuration entry for which the options flow
-                should be opened.
-        Returns:
-            An ``OptionsFlowHandler`` instance that manages the options flow.
-        """
-
-
+    def async_get_options_flow(config_entry: config_entries.ConfigEntry):
         """Return the options flow handler."""
+
+        return OptionsFlowHandler(config_entry)
 
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
-    """Handle option flow for Paw Control to enable/disable modules."""
+    """Handle the options flow for Paw Control."""
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-
-        """Store the config entry so existing options can be loaded.
-
-
-
-        """Store the config entry so existing options can be loaded.
-        Args:
-            config_entry: Entry whose options will be edited. Existing options
-                are used as defaults when presenting the form.
-        """
-
         self.config_entry = config_entry
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:  # pragma: no cover - HA handles step name
-        """Show and persist module options during configuration.
+    ) -> FlowResult:  # pragma: no cover - Home Assistant handles step name
+        """Show and persist module options during configuration."""
 
-        When presented without ``user_input`` the method displays a form with a
-        toggle for every known module. Each toggle defaults to the value stored in
-        the existing options or, if never set, the module's predefined default.
-        When ``user_input`` is provided, the chosen values are saved to the config
-        entry so that selections persist across reloads and Home Assistant
-        restarts.
-
-        Args:
-            user_input: Optional mapping of module keys to boolean values when
-                the user submits the form.
-
-        Returns:
-            A ``FlowResult`` that either shows the form again or writes the
-            provided options to the configuration entry.
-        """
-
-        # Use existing options if present so changes persist across restarts
-
-        self.config_entry = config_entry
-
-    async def async_step_init(self, user_input=None):  # pragma: no cover - HA handles step name
-
-        data = self.config_entry.options or self.config_entry.data
+        data = {**self.config_entry.data, **self.config_entry.options}
 
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
 
-        schema = {}
+        schema: dict[Any, Any] = {}
         for key, module in MODULES.items():
             schema[vol.Optional(key, default=data.get(key, module.default))] = bool
         schema[vol.Optional(
-            CONF_CREATE_DASHBOARD, default=data.get(CONF_CREATE_DASHBOARD, False)
+            CONF_CREATE_DASHBOARD,
+            default=data.get(CONF_CREATE_DASHBOARD, False),
         )] = bool
 
         return self.async_show_form(step_id="init", data_schema=vol.Schema(schema))
+

--- a/validate_installation.py
+++ b/validate_installation.py
@@ -1,13 +1,17 @@
 #!/usr/bin/env python3
 """Validation script for Paw Control installation."""
+from __future__ import annotations
+
 import json
 import sys
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Callable, List
 
 
 def validate_manifest() -> list[str]:
     """Validate manifest.json structure."""
-    errors = []
+    errors: list[str] = []
     manifest_path = Path("custom_components/pawcontrol/manifest.json")
     if not manifest_path.exists():
         return ["❌ manifest.json not found"]
@@ -41,7 +45,7 @@ def validate_manifest() -> list[str]:
 
 def validate_services() -> list[str]:
     """Validate services.yaml structure."""
-    errors = []
+    errors: list[str] = []
     services_path = Path("custom_components/pawcontrol/services.yaml")
     if not services_path.exists():
         return ["⚠️ services.yaml not found (optional)"]
@@ -63,7 +67,7 @@ def validate_services() -> list[str]:
 
 def validate_strings() -> list[str]:
     """Validate strings.json structure."""
-    errors = []
+    errors: list[str] = []
     strings_path = Path("custom_components/pawcontrol/strings.json")
     if not strings_path.exists():
         return ["⚠️ strings.json not found (optional)"]
@@ -84,7 +88,7 @@ def validate_strings() -> list[str]:
 
 def validate_python_files() -> list[str]:
     """Validate Python files for syntax errors."""
-    errors = []
+    errors: list[str] = []
     python_files = list(Path("custom_components/pawcontrol").glob("*.py"))
     if not python_files:
         return ["❌ No Python files found in integration"]
@@ -103,7 +107,7 @@ def validate_python_files() -> list[str]:
 
 def validate_required_files() -> list[str]:
     """Check for required files."""
-    errors = []
+    errors: list[str] = []
     required_files = [
         "custom_components/pawcontrol/__init__.py",
         "custom_components/pawcontrol/manifest.json",
@@ -118,41 +122,48 @@ def validate_required_files() -> list[str]:
     return errors
 
 
-def main():
+@dataclass
+class Validation:
+    """Single validation step."""
+
+    name: str
+    func: Callable[[], list[str]]
+
+
+VALIDATIONS: List[Validation] = [
+    Validation("Required Files", validate_required_files),
+    Validation("Manifest", validate_manifest),
+    Validation("Services", validate_services),
+    Validation("Strings", validate_strings),
+    Validation("Python Syntax", validate_python_files),
+]
+
+
+def main() -> None:
     """Run all validations."""
     print("🔍 Validating Paw Control installation...\n")
 
-    all_errors = []
+    all_errors: list[str] = []
 
-    # Run all validations
-    validations = [
-        ("Required Files", validate_required_files),
-        ("Manifest", validate_manifest),
-        ("Services", validate_services),
-        ("Strings", validate_strings),
-        ("Python Syntax", validate_python_files),
-    ]
-
-    for name, validator in validations:
-        print(f"📋 Checking {name}...")
-        errors = validator()
+    for validation in VALIDATIONS:
+        print(f"📋 Checking {validation.name}...")
+        errors = validation.func()
         if errors:
             all_errors.extend(errors)
             for error in errors:
                 print(f"  {error}")
         else:
-            print(f"  ✅ {name} validation passed")
+            print(f"  ✅ {validation.name} validation passed")
         print()
 
-    # Summary
     if all_errors:
         print(f"❌ Validation failed with {len(all_errors)} errors:")
         for error in all_errors:
             print(f"  {error}")
         sys.exit(1)
-    else:
-        print("✅ All validations passed! Installation is ready.")
-        sys.exit(0)
+
+    print("✅ All validations passed! Installation is ready.")
+    sys.exit(0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- simplify configuration flow and make module toggles explicit
- refactor installation validator into modular dataclass-based checks

## Testing
- `python validate_installation.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fc95e564c833192c870a4516665c3