### PR TITLE
Handle invalid inputs in speed calculation

### DIFF
--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -294,13 +294,19 @@ def format_coordinates(latitude: float, longitude: float, precision: int = 6) ->
 
 def calculate_speed_kmh(distance_m: float, time_seconds: float) -> float:
     """Calculate speed in km/h from distance in meters and time in seconds."""
-    if time_seconds <= 0:
+    try:
+        distance = float(distance_m)
+        seconds = float(time_seconds)
+    except (TypeError, ValueError):
         return 0.0
-    
+
+    if seconds <= 0 or distance < 0 or not isfinite(distance) or not isfinite(seconds):
+        return 0.0
+
     # Convert to km/h
-    speed_ms = distance_m / time_seconds
+    speed_ms = distance / seconds
     speed_kmh = speed_ms * 3.6
-    
+
     return round(speed_kmh, 1)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,7 @@ sys.path.insert(0, os.path.abspath("."))
 
 from custom_components.pawcontrol.utils import (
     calculate_dog_calories_per_day,
+    calculate_speed_kmh,
     format_distance,
     format_duration,
     format_weight,
@@ -41,6 +42,15 @@ def test_format_weight_handles_various_inputs():
     assert format_weight(10) == "10.0kg"
     assert format_weight("bad") == "0.0kg"
     assert format_weight(-5) == "0.0kg"
+
+
+def test_calculate_speed_kmh_handles_invalid_inputs():
+    """Speed calculations should handle invalid or negative values gracefully."""
+    assert calculate_speed_kmh(1000, 3600) == 1.0
+    assert calculate_speed_kmh(-100, 10) == 0.0
+    assert calculate_speed_kmh(100, 0) == 0.0
+    assert calculate_speed_kmh("bad", 10) == 0.0
+    assert calculate_speed_kmh(100, "bad") == 0.0
 
 
 @pytest.mark.parametrize("value", [None, "10", 5.5, -1, 0])


### PR DESCRIPTION
## Summary
- Guard speed calculation against invalid, negative, or non‑finite values to avoid negative speeds
- Add comprehensive tests for speed calculation edge cases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fcc5272808331a9b3e543a1b1f46b