### PR TITLE
Refactor module setup for modular installation

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -7,7 +7,11 @@ from .const import (
     CONF_CREATE_DASHBOARD,
     CONF_DOG_NAME,
 )
-from .module_registry import MODULES
+from .module_registry import (
+    ensure_helpers as module_ensure_helpers,
+    setup_modules as module_setup_modules,
+    unload_modules as module_unload_modules,
+)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
@@ -15,14 +19,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     opts = entry.options if entry.options else entry.data
 
     # 1. Alle benötigten Helper automatisch prüfen/erstellen (je nach Modulstatus)
-    await ensure_helpers(hass, opts)
+    await module_ensure_helpers(hass, opts)
 
     # 2. Modul-Setup je nach Opt-in/Opt-out
-    for key, module in MODULES.items():
-        if opts.get(key, module.default):
-            await module.setup(hass, entry)
-        elif module.teardown:
-            await module.teardown(hass, entry)
+    await module_setup_modules(hass, entry, opts)
 
     if opts.get(CONF_CREATE_DASHBOARD, False):
         await dashboard.create_dashboard(hass, opts[CONF_DOG_NAME])
@@ -31,17 +31,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
 async def async_unload_entry(hass, entry):
     """Beim Entfernen der Integration: alle Module/Helper aufräumen."""
-    for module in MODULES.values():
-        if module.teardown:
-            await module.teardown(hass, entry)
+    await module_unload_modules(hass, entry)
     # Dashboard bleibt, falls es nicht explizit entfernt werden soll.
     return True
-
-async def ensure_helpers(hass, opts):
-    """Prüft und legt alle für aktivierte Module nötigen Helper/Sensoren an."""
-    # Beispiel: Health-Status, Walk-Counter, GPS-Status, ...
-    # (Diese Logik ruft die Helper-Init der jeweiligen Module auf.)
-    for key, module in MODULES.items():
-        if opts.get(key, module.default) and module.ensure_helpers:
-            await module.ensure_helpers(hass, opts)
-    # Usw. für weitere Module

--- a/custom_components/pawcontrol/module_registry.py
+++ b/custom_components/pawcontrol/module_registry.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 
 from typing import Awaitable, Callable, Dict, Optional
 
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
 from .const import (
     CONF_GPS_ENABLE,
     CONF_NOTIFICATIONS_ENABLED,
@@ -56,3 +59,28 @@ MODULES: Dict[str, Module] = {
         default=True,
     ),
 }
+
+
+async def ensure_helpers(hass: HomeAssistant, opts: Dict[str, bool]) -> None:
+    """Ensure helpers for all enabled modules."""
+    for key, module in MODULES.items():
+        if opts.get(key, module.default) and module.ensure_helpers:
+            await module.ensure_helpers(hass, opts)
+
+
+async def setup_modules(
+    hass: HomeAssistant, entry: ConfigEntry, opts: Dict[str, bool]
+) -> None:
+    """Set up or tear down modules based on options."""
+    for key, module in MODULES.items():
+        if opts.get(key, module.default):
+            await module.setup(hass, entry)
+        elif module.teardown:
+            await module.teardown(hass, entry)
+
+
+async def unload_modules(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Unload all modules that define a teardown handler."""
+    for module in MODULES.values():
+        if module.teardown:
+            await module.teardown(hass, entry)


### PR DESCRIPTION
## Summary
- centralize helper creation, setup, and teardown logic for optional modules
- simplify integration entry setup to use new module registry helpers

## Testing
- `python -m pytest`
- `python validate_installation.py`


------
https://chatgpt.com/codex/tasks/task_e_688fce508bd48331a71f4255412a6b32