### PR TITLE
refactor: modularize module setup

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -7,7 +7,11 @@ from .const import (
     CONF_CREATE_DASHBOARD,
     CONF_DOG_NAME,
 )
-from .module_registry import MODULES
+from .module_registry import (
+    async_ensure_helpers,
+    async_setup_modules,
+    async_unload_modules,
+)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
@@ -15,33 +19,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     opts = entry.options if entry.options else entry.data
 
     # 1. Alle benötigten Helper automatisch prüfen/erstellen (je nach Modulstatus)
-    await ensure_helpers(hass, opts)
+    await async_ensure_helpers(hass, opts)
 
     # 2. Modul-Setup je nach Opt-in/Opt-out
-    for key, module in MODULES.items():
-        if opts.get(key, module.default):
-            await module.setup(hass, entry)
-        elif module.teardown:
-            await module.teardown(hass, entry)
+    await async_setup_modules(hass, entry, opts)
 
     if opts.get(CONF_CREATE_DASHBOARD, False):
         await dashboard.create_dashboard(hass, opts[CONF_DOG_NAME])
 
     return True
 
+
 async def async_unload_entry(hass, entry):
     """Beim Entfernen der Integration: alle Module/Helper aufräumen."""
-    for module in MODULES.values():
-        if module.teardown:
-            await module.teardown(hass, entry)
+    await async_unload_modules(hass, entry)
     # Dashboard bleibt, falls es nicht explizit entfernt werden soll.
     return True
-
-async def ensure_helpers(hass, opts):
-    """Prüft und legt alle für aktivierte Module nötigen Helper/Sensoren an."""
-    # Beispiel: Health-Status, Walk-Counter, GPS-Status, ...
-    # (Diese Logik ruft die Helper-Init der jeweiligen Module auf.)
-    for key, module in MODULES.items():
-        if opts.get(key, module.default) and module.ensure_helpers:
-            await module.ensure_helpers(hass, opts)
-    # Usw. für weitere Module

--- a/custom_components/pawcontrol/module_registry.py
+++ b/custom_components/pawcontrol/module_registry.py
@@ -1,7 +1,10 @@
-"""Registry for optional Paw Control modules."""
+"""Registry and helpers for optional Paw Control modules."""
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Awaitable, Callable, Dict, Optional
+
+from homeassistant.core import HomeAssistant
 
 from .const import (
     CONF_GPS_ENABLE,
@@ -15,20 +18,14 @@ from . import gps, push, health, walk
 ModuleFunc = Callable[..., Awaitable[None]]
 
 
+@dataclass
 class Module:
     """Container for module handlers."""
 
-    def __init__(
-        self,
-        setup: ModuleFunc,
-        teardown: Optional[ModuleFunc] = None,
-        ensure_helpers: Optional[ModuleFunc] = None,
-        default: bool = True,
-    ) -> None:
-        self.setup = setup
-        self.teardown = teardown
-        self.ensure_helpers = ensure_helpers
-        self.default = default
+    setup: ModuleFunc
+    teardown: Optional[ModuleFunc] = None
+    ensure_helpers: Optional[ModuleFunc] = None
+    default: bool = True
 
 
 MODULES: Dict[str, Module] = {
@@ -56,3 +53,28 @@ MODULES: Dict[str, Module] = {
         default=True,
     ),
 }
+
+
+async def async_ensure_helpers(hass: HomeAssistant, opts: Dict[str, bool]) -> None:
+    """Ensure helpers for all enabled modules."""
+    for key, module in MODULES.items():
+        if opts.get(key, module.default) and module.ensure_helpers:
+            await module.ensure_helpers(hass, opts)
+
+
+async def async_setup_modules(
+    hass: HomeAssistant, entry, opts: Dict[str, bool]
+) -> None:
+    """Set up or tear down modules based on configuration."""
+    for key, module in MODULES.items():
+        if opts.get(key, module.default):
+            await module.setup(hass, entry)
+        elif module.teardown:
+            await module.teardown(hass, entry)
+
+
+async def async_unload_modules(hass: HomeAssistant, entry) -> None:
+    """Unload all modules."""
+    for module in MODULES.values():
+        if module.teardown:
+            await module.teardown(hass, entry)

--- a/tests/test_module_registry.py
+++ b/tests/test_module_registry.py
@@ -96,6 +96,33 @@ def test_module_enable_disable(monkeypatch, module_key):
     asyncio.run(run_test())
 
 
+def test_module_helpers_and_unload():
+    """Verify helper creation, setup and unload utilities."""
+
+    async def run_test():
+        test_module = module_registry.Module(
+            setup=AsyncMock(),
+            teardown=AsyncMock(),
+            ensure_helpers=AsyncMock(),
+        )
+        hass = object()
+        entry = object()
+        opts = {"test": True}
+
+        with patch.dict(module_registry.MODULES, {"test": test_module}, clear=True):
+            await module_registry.async_ensure_helpers(hass, opts)
+            test_module.ensure_helpers.assert_called_once_with(hass, opts)
+
+            await module_registry.async_setup_modules(hass, entry, opts)
+            test_module.setup.assert_called_once_with(hass, entry)
+
+            await module_registry.async_unload_modules(hass, entry)
+            test_module.teardown.assert_called_once_with(hass, entry)
+
+    import asyncio
+    asyncio.run(run_test())
+
+
 def test_options_flow_defaults_and_persistence():
     """Ensure options flow shows correct defaults and persists selections."""
 


### PR DESCRIPTION
## Summary
- centralize optional module management with dataclass registry and helper functions
- simplify integration setup/unload logic to use centralized helpers
- test helper creation/setup/unload flows

## Testing
- `python validate_installation.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fce508bd48331a71f4255412a6b32