### PR TITLE
Refactor installation manager

### DIFF
--- a/custom_components/pawcontrol/installation_manager.py
+++ b/custom_components/pawcontrol/installation_manager.py
@@ -1,14 +1,16 @@
 """Modular setup and teardown manager for Paw Control."""
 from __future__ import annotations
 
-from typing import Dict
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from . import dashboard
 from .const import CONF_CREATE_DASHBOARD, CONF_DOG_NAME
-from .module_registry import MODULES
+from .module_manager import (
+    async_ensure_helpers,
+    async_setup_modules,
+    async_unload_modules,
+)
 
 
 class InstallationManager:
@@ -16,17 +18,12 @@ class InstallationManager:
 
     async def setup_entry(self, hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Set up the integration and selected modules."""
-        opts = entry.options if entry.options else entry.data
+        # Merge config entry data and options, with options taking precedence
+        opts = {**entry.data, **entry.options}
 
-        # Ensure helper entities for all enabled modules
-        await self.ensure_helpers(hass, opts)
-
-        # Run setup or teardown for each module based on options
-        for key, module in MODULES.items():
-            if opts.get(key, module.default):
-                await module.setup(hass, entry)
-            elif module.teardown:
-                await module.teardown(hass, entry)
+        # Ensure helper entities for enabled modules then set them up
+        await async_ensure_helpers(hass, opts)
+        await async_setup_modules(hass, entry, opts)
 
         # Create dashboard if requested
         if opts.get(CONF_CREATE_DASHBOARD, False):
@@ -36,13 +33,5 @@ class InstallationManager:
 
     async def unload_entry(self, hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Unload the integration and clean up modules."""
-        for module in MODULES.values():
-            if module.teardown:
-                await module.teardown(hass, entry)
+        await async_unload_modules(hass, entry)
         return True
-
-    async def ensure_helpers(self, hass: HomeAssistant, opts: Dict) -> None:
-        """Create helper entities for all enabled modules."""
-        for key, module in MODULES.items():
-            if opts.get(key, module.default) and module.ensure_helpers:
-                await module.ensure_helpers(hass, opts)

--- a/tests/test_module_registry.py
+++ b/tests/test_module_registry.py
@@ -52,7 +52,11 @@ def test_module_enable_disable(monkeypatch, module_key):
 
         setup_mock, teardown_mock, helper_mock = patched[module_key]
         setup_mock.assert_called_once_with(hass, entry)
-        helper_mock.assert_called_once_with(hass, result['data'])
+        helper_mock.assert_called_once()
+        called_hass, called_opts = helper_mock.call_args[0]
+        assert called_hass is hass
+        assert called_opts[module_key] is True
+        assert called_opts[CONF_DOG_NAME] == 'Fido'
         teardown_mock.assert_not_called()
 
         setup_mock.reset_mock()
@@ -89,7 +93,11 @@ def test_module_enable_disable(monkeypatch, module_key):
         await integration.async_setup_entry(hass, entry)
 
         setup_mock.assert_called_once_with(hass, entry)
-        helper_mock.assert_called_once_with(hass, entry.options)
+        helper_mock.assert_called_once()
+        called_hass2, called_opts2 = helper_mock.call_args[0]
+        assert called_hass2 is hass
+        assert called_opts2[module_key] is True
+        assert called_opts2[CONF_DOG_NAME] == 'Fido'
         teardown_mock.assert_not_called()
 
     import asyncio


### PR DESCRIPTION
## Summary
- centralize module setup/teardown through module_manager
- merge entry data and options for accurate module enablement
- adjust tests for updated helper argument handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fd3bb54d88331994a886e0e36d545