### PR TITLE
Handle missing dog name when generating dashboard

### DIFF
--- a/custom_components/pawcontrol/installation_manager.py
+++ b/custom_components/pawcontrol/installation_manager.py
@@ -1,6 +1,8 @@
 """Modular setup and teardown manager for Paw Control."""
 from __future__ import annotations
 
+import logging
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
@@ -11,6 +13,8 @@ from .module_registry import (
     async_setup_modules,
     async_unload_modules,
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class InstallationManager:
@@ -25,9 +29,15 @@ class InstallationManager:
         await async_ensure_helpers(hass, opts)
         await async_setup_modules(hass, entry, opts)
 
-        # Create dashboard if requested
+        # Create dashboard if requested (requires dog name)
         if opts.get(CONF_CREATE_DASHBOARD, False):
-            await dashboard.create_dashboard(hass, opts[CONF_DOG_NAME])
+            dog_name = opts.get(CONF_DOG_NAME)
+            if dog_name:
+                await dashboard.create_dashboard(hass, dog_name)
+            else:
+                _LOGGER.warning(
+                    "Dashboard creation requested but no dog name provided"
+                )
 
         return True
 

--- a/tests/test_installation_manager.py
+++ b/tests/test_installation_manager.py
@@ -1,0 +1,50 @@
+import asyncio
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from homeassistant import config_entries
+
+sys.path.insert(0, os.path.abspath("."))
+
+from custom_components.pawcontrol.const import DOMAIN, CONF_CREATE_DASHBOARD
+from custom_components.pawcontrol.installation_manager import InstallationManager
+
+
+def test_setup_entry_handles_missing_dog_name():
+    """Dashboard creation should be skipped gracefully if dog name missing."""
+
+    async def run_test():
+        hass = SimpleNamespace()
+        entry = config_entries.ConfigEntry(
+            version=1,
+            minor_version=1,
+            domain=DOMAIN,
+            title="Test",
+            data={},
+            source="user",
+        )
+        entry.options = {CONF_CREATE_DASHBOARD: True}
+
+        manager = InstallationManager()
+
+        with patch(
+            "custom_components.pawcontrol.installation_manager.async_ensure_helpers",
+            new=AsyncMock(),
+        ) as ensure_helpers, patch(
+            "custom_components.pawcontrol.installation_manager.async_setup_modules",
+            new=AsyncMock(),
+        ) as setup_modules, patch(
+            "custom_components.pawcontrol.dashboard.create_dashboard",
+            new=AsyncMock(),
+        ) as create_dashboard:
+            result = await manager.setup_entry(hass, entry)
+            assert result is True
+            ensure_helpers.assert_awaited_once_with(hass, {CONF_CREATE_DASHBOARD: True})
+            setup_modules.assert_awaited_once_with(
+                hass, entry, {CONF_CREATE_DASHBOARD: True}
+            )
+            create_dashboard.assert_not_called()
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- Skip dashboard creation when a dog name isn't provided and log a warning
- Cover installation manager behaviour with a dedicated test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fd6cb179483318831cf4a1bea135c