### PR TITLE
Avoid teardown for default-off modules

### DIFF
--- a/custom_components/pawcontrol/README.md
+++ b/custom_components/pawcontrol/README.md
@@ -27,6 +27,8 @@
 
 Während der Einrichtung und im Optionsdialog werden alle verfügbaren Module als Schalter angezeigt. Ein aktivierter Schalter richtet die zugehörigen Sensoren, Helper und Automationen ein; beim Deaktivieren werden sie wieder entfernt.
 
+Der Teardown-Handler eines Moduls wird nur ausgeführt, wenn dieses in den Optionen ausdrücklich auf `Aus` gesetzt ist. Module, die standardmäßig deaktiviert sind und in den Optionen fehlen, werden dabei ignoriert.
+
 ![Options Flow mit Modul-Schaltern](images/options_flow.svg)
 
 Die Module lassen sich jederzeit über `Einstellungen → Geräte & Dienste → Paw Control → Optionen` anpassen.

--- a/tests/test_module_registry.py
+++ b/tests/test_module_registry.py
@@ -271,7 +271,7 @@ def test_default_opt_precedence():
             default_on.teardown.assert_not_called()
             default_off.ensure_helpers.assert_not_called()
             default_off.setup.assert_not_called()
-            default_off.teardown.assert_called_once_with(hass, entry)
+            default_off.teardown.assert_not_called()
 
             default_on.ensure_helpers.reset_mock()
             default_on.setup.reset_mock()


### PR DESCRIPTION
## Summary
- refine module setup logic to skip teardown for modules disabled by default
- update docstrings and README to document that teardown only occurs when a module is explicitly disabled

## Testing
- `pytest`
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit (proxy 403))*
- `pre-commit run --files custom_components/pawcontrol/module_registry.py custom_components/pawcontrol/README.md tests/test_module_registry.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ffb6941088331be545fbbf68c679f