### PR TITLE
Fix installation helper import and config default handling

### DIFF
--- a/custom_components/pawcontrol/config_flow.py
+++ b/custom_components/pawcontrol/config_flow.py
@@ -48,10 +48,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         schema: dict[Any, Any] = {
             vol.Required(CONF_DOG_NAME): str,
             vol.Optional(CONF_DOG_BREED, default=""): str,
-            vol.Optional(CONF_DOG_AGE, default=0): int,
-            vol.Optional(CONF_DOG_WEIGHT, default=0.0): float,
-            vol.Optional(CONF_FEEDING_TIMES, default=DEFAULT_FEEDING_TIMES): list,
-            vol.Optional(CONF_WALK_DURATION, default=DEFAULT_WALK_DURATION): int,
+            vol.Optional(CONF_DOG_AGE, default=0): vol.All(vol.Coerce(int), vol.Range(min=0)),
+            vol.Optional(CONF_DOG_WEIGHT, default=0.0): vol.All(vol.Coerce(float), vol.Range(min=0)),
+            vol.Optional(
+                CONF_FEEDING_TIMES,
+                default=list(DEFAULT_FEEDING_TIMES),
+            ): list,
+            vol.Optional(CONF_WALK_DURATION, default=DEFAULT_WALK_DURATION): vol.All(vol.Coerce(int), vol.Range(min=0)),
             vol.Optional(CONF_VET_CONTACT, default=""): str,
         }
         # Add toggles for modules and dashboard creation

--- a/custom_components/pawcontrol/helpers.py
+++ b/custom_components/pawcontrol/helpers.py
@@ -16,8 +16,7 @@ from .const import (
     CONF_DOG_NAME,
     ENTITIES,
     FEEDING_TYPES,
-    MEAL_TYPES,
-    DEFAULT_FEEDING_TIMES_DICT,
+    MEAL_TYPES
 )
 from .utils import safe_service_call, normalize_dog_name
 

--- a/tests/test_config_flow_defaults.py
+++ b/tests/test_config_flow_defaults.py
@@ -1,0 +1,39 @@
+import asyncio
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("."))
+
+import custom_components.pawcontrol.config_flow as config_flow
+import custom_components.pawcontrol.const as const
+
+from custom_components.pawcontrol.const import CONF_DOG_NAME, CONF_FEEDING_TIMES
+
+
+@pytest.mark.parametrize(
+    "defaults",
+    [
+        [],
+        ["08:00"],
+        ["08:00", "20:00"],
+    ],
+)
+def test_feeding_times_default_is_copied(defaults, monkeypatch):
+    monkeypatch.setattr(const, "DEFAULT_FEEDING_TIMES", list(defaults))
+    monkeypatch.setattr(
+        config_flow, "DEFAULT_FEEDING_TIMES", const.DEFAULT_FEEDING_TIMES
+    )
+
+    flow = config_flow.ConfigFlow()
+    flow.hass = SimpleNamespace()
+
+    result = asyncio.run(flow.async_step_user())
+    data = result["data_schema"]({CONF_DOG_NAME: "Rex"})
+    assert data[CONF_FEEDING_TIMES] == defaults
+    assert data[CONF_FEEDING_TIMES] is not config_flow.DEFAULT_FEEDING_TIMES
+    data[CONF_FEEDING_TIMES].append("extra")
+    assert config_flow.DEFAULT_FEEDING_TIMES == defaults
+    assert const.DEFAULT_FEEDING_TIMES == defaults

--- a/tests/test_helpers_import.py
+++ b/tests/test_helpers_import.py
@@ -1,0 +1,9 @@
+import importlib
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("."))
+
+
+def test_helpers_importable():
+    importlib.import_module("custom_components.pawcontrol.helpers")


### PR DESCRIPTION
## Summary
- avoid import error by dropping unused DEFAULT_FEEDING_TIMES_DICT from helpers
- validate numeric options and copy feeding time defaults in config flow
- test helper module import and safe copying of feeding time defaults, including varied default list lengths

## Testing
- `pre-commit run --files tests/test_config_flow_defaults.py` *(command not found)*
- `pip install pre-commit` *(failed: 403 Forbidden)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890000f9bb083318e05dd9b1211ab16