### PR TITLE
Use shared dog name regex and add validation tests

### DIFF
--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -25,25 +25,29 @@ from .exceptions import InvalidCoordinates, DataValidationError
 _LOGGER = logging.getLogger(__name__)
 
 
+# Precompile dog name pattern for reuse
+DOG_NAME_RE = re.compile(DOG_NAME_PATTERN)
+
+
 def validate_dog_name(name: str) -> bool:
     """Validate dog name format and constraints."""
     if not name or not isinstance(name, str):
         return False
-    
+
     name = name.strip()
-    
+
     # Check length
     if len(name) < MIN_DOG_NAME_LENGTH or len(name) > MAX_DOG_NAME_LENGTH:
         return False
-    
+
     # Check for valid characters (letters, numbers, spaces, common punctuation)
-    if not re.match(r'^[a-zA-ZäöüÄÖÜß0-9\s\-_.]+$', name):
+    if not DOG_NAME_RE.match(name):
         return False
-    
+
     # Must start with a letter
     if not name[0].isalpha():
         return False
-    
+
     return True
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,6 +14,7 @@ from custom_components.pawcontrol.utils import (
     format_duration,
     format_weight,
     time_since_last_activity,
+    validate_dog_name,
 )
 
 
@@ -107,3 +108,11 @@ def test_time_since_last_activity_accepts_datetime_object():
     expected = datetime.now() - past_time
     assert isinstance(result, timedelta)
     assert abs(result - expected) <= tolerance
+
+
+def test_validate_dog_name_enforces_rules():
+    """Dog names must follow pattern, length and start with a letter."""
+    assert validate_dog_name("Buddy")
+    assert not validate_dog_name("1Buddy")
+    assert not validate_dog_name("Bad!")
+    assert not validate_dog_name("a" * 31)


### PR DESCRIPTION
## Summary
- reuse shared dog name pattern in `validate_dog_name`
- add tests for dog name validation rules

## Testing
- `pytest`
- `pre-commit run --files custom_components/pawcontrol/utils.py tests/test_utils.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890205414d88331bd179dbfb7a48846