### PR TITLE
Expose Module dataclass in module manager

### DIFF
--- a/custom_components/pawcontrol/module_manager.py
+++ b/custom_components/pawcontrol/module_manager.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from .module_registry import (
     MODULES,
+    Module,
     async_ensure_helpers,
     async_setup_modules,
     async_unload_modules,
@@ -17,6 +18,7 @@ from .module_registry import (
 
 __all__ = [
     "MODULES",
+    "Module",
     "async_ensure_helpers",
     "async_setup_modules",
     "async_unload_modules",


### PR DESCRIPTION
## Summary
- re-export `Module` dataclass in `module_manager` for full backward compatibility

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689021b02f3083318f74d8b61c97ce36