### PR TITLE
refactor: centralize safe service calls

### DIFF
--- a/custom_components/pawcontrol/button.py
+++ b/custom_components/pawcontrol/button.py
@@ -13,6 +13,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, ICONS, ATTR_DOG_NAME, ATTR_LAST_UPDATED
 from .coordinator import PawControlCoordinator
+from .utils import safe_service_call
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -83,13 +84,8 @@ class PawControlButtonBase(CoordinatorEntity, ButtonEntity):
         }
 
     async def _safe_service_call(self, domain: str, service: str, data: dict) -> bool:
-        """Safely call a service with error handling."""
-        try:
-            await self.hass.services.async_call(domain, service, data, blocking=True)
-            return True
-        except Exception as e:
-            _LOGGER.error("Service call %s.%s failed for %s: %s", domain, service, self._dog_name, e)
-            return False
+        """Safely call a service with consistent error handling."""
+        return await safe_service_call(self.hass, domain, service, data)
 
 
 # FEEDING BUTTONS

--- a/custom_components/pawcontrol/service_handlers.py
+++ b/custom_components/pawcontrol/service_handlers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from datetime import datetime
 from homeassistant.core import HomeAssistant
+
 from .const import (
     SERVICE_FOOD_TYPE,
     SERVICE_FOOD_AMOUNT,
@@ -15,6 +16,8 @@ from .const import (
     SERVICE_MOOD,
     SERVICE_VET_DATE,
 )
+
+from .utils import safe_service_call
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -469,15 +472,3 @@ async def end_walk_tracking(hass: HomeAssistant, dog_name: str, data: dict) -> N
         
     except Exception as e:
         _LOGGER.error("Error ending walk tracking for %s: %s", dog_name, e)
-
-
-async def safe_service_call(hass: HomeAssistant, domain: str, service: str, data: dict) -> None:
-    """Make a safe service call with error handling."""
-    try:
-        entity_id = data.get("entity_id")
-        if entity_id and hass.states.get(entity_id):
-            await hass.services.async_call(domain, service, data, blocking=True)
-        else:
-            _LOGGER.debug("Entity %s not found, skipping service call", entity_id)
-    except Exception as e:
-        _LOGGER.debug("Service call failed %s.%s: %s", domain, service, e)

--- a/custom_components/pawcontrol/switch.py
+++ b/custom_components/pawcontrol/switch.py
@@ -13,6 +13,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, ICONS, ATTR_DOG_NAME, ATTR_LAST_UPDATED
 from .coordinator import PawControlCoordinator
+from .utils import safe_service_call
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -81,13 +82,8 @@ class PawControlSwitchBase(CoordinatorEntity, SwitchEntity):
         }
 
     async def _safe_service_call(self, domain: str, service: str, data: dict) -> bool:
-        """Safely call a service with error handling."""
-        try:
-            await self.hass.services.async_call(domain, service, data, blocking=True)
-            return True
-        except Exception as e:
-            _LOGGER.error("Service call %s.%s failed for %s: %s", domain, service, self._dog_name, e)
-            return False
+        """Safely call a service with consistent error handling."""
+        return await safe_service_call(self.hass, domain, service, data)
 
 
 # SYSTEM SWITCHES


### PR DESCRIPTION
## Summary
- centralize service call error handling in shared `safe_service_call`
- reuse `safe_service_call` in buttons, switches, service handlers, and GPS coordinator
- add missing `asyncio` import to GPS coordinator

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68902367eab483319d0e8c5a52d577d2