### PR TITLE
refactor: streamline service setup and helpers

### DIFF
--- a/custom_components/pawcontrol/installation_manager.py
+++ b/custom_components/pawcontrol/installation_manager.py
@@ -23,7 +23,7 @@ class InstallationManager:
     async def setup_entry(self, hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Set up the integration and selected modules."""
         # Merge config entry data and options, with options taking precedence
-        opts = {**entry.data, **entry.options}
+        opts = entry.data | entry.options
 
         # Some parts of the integration – especially helper creation – expect a
         # dog name to be present.  The title of the entry is the dog name in the
@@ -31,8 +31,7 @@ class InstallationManager:
         # stored data. This allows setup to proceed without crashing when the
         # data is incomplete while still making the name available to modules.
         dog_present = CONF_DOG_NAME in opts
-        opts.setdefault(CONF_DOG_NAME, entry.title)
-        dog_name = opts.get(CONF_DOG_NAME)
+        dog_name = opts.setdefault(CONF_DOG_NAME, entry.title)
 
         # Ensure helper entities for enabled modules then set them up
         await async_ensure_helpers(hass, opts)

--- a/custom_components/pawcontrol/script_system.py
+++ b/custom_components/pawcontrol/script_system.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
 import logging
-import asyncio
-from datetime import datetime, timedelta
-from typing import Dict, List, Any, Optional
+from datetime import datetime
 
-from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers.script import Script
-from homeassistant.helpers import entity_registry
 
 from .const import (
     DOMAIN,
@@ -80,73 +77,30 @@ class PawControlScriptManager:
     async def async_setup_services(self) -> None:
         """Set up all services."""
         try:
-            # Register feeding services
-            self.hass.services.async_register(
-                DOMAIN, SERVICE_FEED_DOG, self._feed_dog_service,
-                schema=None
+            services = {
+                SERVICE_FEED_DOG: self._feed_dog_service,
+                SERVICE_WALK_DOG: self._walk_dog_service,
+                SERVICE_PLAY_WITH_DOG: self._play_with_dog_service,
+                SERVICE_TRAINING_SESSION: self._training_session_service,
+                SERVICE_HEALTH_CHECK: self._health_check_service,
+                SERVICE_MEDICATION_GIVEN: self._medication_given_service,
+                SERVICE_VET_VISIT: self._vet_visit_service,
+                SERVICE_GROOMING_SESSION: self._grooming_session_service,
+                SERVICE_EMERGENCY_MODE: self._emergency_mode_service,
+                SERVICE_VISITOR_MODE: self._visitor_mode_service,
+                SERVICE_DAILY_RESET: self._daily_reset_service,
+                SERVICE_GENERATE_REPORT: self._generate_report_service,
+            }
+
+            for service, handler in services.items():
+                self.hass.services.async_register(
+                    DOMAIN, service, handler, schema=None
+                )
+
+            _LOGGER.info(
+                "Registered %d services for %s", len(services), self._dog_name
             )
-            
-            # Register activity services
-            self.hass.services.async_register(
-                DOMAIN, SERVICE_WALK_DOG, self._walk_dog_service,
-                schema=None
-            )
-            
-            self.hass.services.async_register(
-                DOMAIN, SERVICE_PLAY_WITH_DOG, self._play_with_dog_service,
-                schema=None
-            )
-            
-            self.hass.services.async_register(
-                DOMAIN, SERVICE_TRAINING_SESSION, self._training_session_service,
-                schema=None
-            )
-            
-            # Register health services
-            self.hass.services.async_register(
-                DOMAIN, SERVICE_HEALTH_CHECK, self._health_check_service,
-                schema=None
-            )
-            
-            self.hass.services.async_register(
-                DOMAIN, SERVICE_MEDICATION_GIVEN, self._medication_given_service,
-                schema=None
-            )
-            
-            self.hass.services.async_register(
-                DOMAIN, SERVICE_VET_VISIT, self._vet_visit_service,
-                schema=None
-            )
-            
-            # Register care services
-            self.hass.services.async_register(
-                DOMAIN, SERVICE_GROOMING_SESSION, self._grooming_session_service,
-                schema=None
-            )
-            
-            # Register system services
-            self.hass.services.async_register(
-                DOMAIN, SERVICE_EMERGENCY_MODE, self._emergency_mode_service,
-                schema=None
-            )
-            
-            self.hass.services.async_register(
-                DOMAIN, SERVICE_VISITOR_MODE, self._visitor_mode_service,
-                schema=None
-            )
-            
-            self.hass.services.async_register(
-                DOMAIN, SERVICE_DAILY_RESET, self._daily_reset_service,
-                schema=None
-            )
-            
-            self.hass.services.async_register(
-                DOMAIN, SERVICE_GENERATE_REPORT, self._generate_report_service,
-                schema=None
-            )
-            
-            _LOGGER.info("Registered %d services for %s", 12, self._dog_name)
-            
+
         except Exception as e:
             _LOGGER.error("Error setting up services for %s: %s", self._dog_name, e)
             raise

--- a/custom_components/pawcontrol/services.yaml
+++ b/custom_components/pawcontrol/services.yaml
@@ -7,6 +7,7 @@ feed_dog:
       required: true
       selector:
         text:
+
     meal_type:
       description: Art der Mahlzeit
       example: "morning"
@@ -15,7 +16,7 @@ feed_dog:
         select:
           options:
             - "morning"
-            - "launch"
+            - "lunch"
             - "evening"
             - "snack"
     amount:

--- a/custom_components/pawcontrol/setup_helpers.py
+++ b/custom_components/pawcontrol/setup_helpers.py
@@ -1,37 +1,41 @@
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_component import async_update_entity
-from homeassistant.helpers.entity_registry import async_get
-from homeassistant.helpers.typing import ConfigType
+"""Helper creation utilities for Paw Control."""
 
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant
 from homeassistant.components.input_datetime import (
-    DOMAIN as INPUT_DATETIME_DOMAIN
+    DOMAIN as INPUT_DATETIME_DOMAIN,
 )
 from homeassistant.components.input_boolean import (
-    DOMAIN as INPUT_BOOLEAN_DOMAIN
+    DOMAIN as INPUT_BOOLEAN_DOMAIN,
 )
 from homeassistant.components.counter import (
-    DOMAIN as COUNTER_DOMAIN
+    DOMAIN as COUNTER_DOMAIN,
 )
-
 from homeassistant.util.dt import now
 
-async def async_create_helpers_for_dog(hass: HomeAssistant, dog_id: str):
-    """Erzeuge benötigte Helfer für Gassi, Fütterung, Geschäft, Besucher-Modus."""
+from .utils import safe_service_call
 
-    # Timestamp Helper (z.B. letzter Gassi)
-    await hass.services.async_call(
+
+async def async_create_helpers_for_dog(hass: HomeAssistant, dog_id: str) -> None:
+    """Create helper entities required for core features."""
+
+    async def _svc(domain: str, service: str, data: dict) -> None:
+        await safe_service_call(hass, domain, service, data)
+
+    # Timestamp Helper (e.g. last walk)
+    await _svc(
         INPUT_DATETIME_DOMAIN,
         "set_datetime",
         {
             "entity_id": f"input_datetime.last_walk_{dog_id}",
-            "timestamp": now().timestamp()
+            "timestamp": now().timestamp(),
         },
-        blocking=True
     )
 
-    # Counter für tägliche Ereignisse
+    # Counters for daily events
     for counter in ["feeding", "walk", "potty"]:
-        await hass.services.async_call(
+        await _svc(
             COUNTER_DOMAIN,
             "configure",
             {
@@ -40,29 +44,23 @@ async def async_create_helpers_for_dog(hass: HomeAssistant, dog_id: str):
                 "minimum": 0,
                 "maximum": 20,
                 "step": 1,
-                "restore": True
+                "restore": True,
             },
-            blocking=True
         )
 
-    # Boolean: Besucher-Modus für diesen Hund
-    await hass.services.async_call(
+    # Boolean: visitor mode for this dog
+    await _svc(
         INPUT_BOOLEAN_DOMAIN,
         "turn_off",
-        {
-            "entity_id": f"input_boolean.visitor_mode_{dog_id}"
-        },
-        blocking=True
+        {"entity_id": f"input_boolean.visitor_mode_{dog_id}"},
     )
 
-
-    # Letzte Aktivität
-    await hass.services.async_call(
+    # Last activity text helper
+    await _svc(
         "input_text",
         "set_value",
         {
             "entity_id": f"input_text.last_activity_{dog_id}",
-            "value": "Noch keine Aktivität"
+            "value": "Noch keine Aktivität",
         },
-        blocking=True
     )


### PR DESCRIPTION
## Summary
- centralize module handling via helper function
- streamline options merge and service registration
- add utility helpers for setup and service calls

## Testing
- `pytest`
- `pre-commit run --files custom_components/pawcontrol/installation_manager.py custom_components/pawcontrol/module_registry.py custom_components/pawcontrol/script_system.py custom_components/pawcontrol/service_handlers.py custom_components/pawcontrol/services.yaml custom_components/pawcontrol/setup_helpers.py custom_components/pawcontrol/setup_verifier.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68902c18fb608331b425018a6482fd6c