### PR TITLE
refactor: centralize options and services

### DIFF
--- a/custom_components/pawcontrol/actionable_push.py
+++ b/custom_components/pawcontrol/actionable_push.py
@@ -4,6 +4,8 @@ import logging
 _LOGGER = logging.getLogger(__name__)
 DOMAIN = "pawcontrol"
 
+from .utils import register_services
+
 async def handle_send_notification(call: ServiceCall):
     hass: HomeAssistant = call.hass
     dog_name = call.data.get("dog_name")
@@ -54,4 +56,4 @@ async def handle_send_notification(call: ServiceCall):
         )
 
 def setup_actionable_notifications(hass: HomeAssistant):
-    hass.services.async_register(DOMAIN, "send_notification", handle_send_notification)
+    register_services(hass, DOMAIN, {"send_notification": handle_send_notification})

--- a/custom_components/pawcontrol/gps_system.py
+++ b/custom_components/pawcontrol/gps_system.py
@@ -10,6 +10,7 @@ from homeassistant.components.device_tracker import SourceType, DeviceTrackerEnt
 from homeassistant.components.binary_sensor import BinarySensorEntity, DEVICE_CLASS_PROBLEM
 from homeassistant.components.button import ButtonEntity
 from .const import DOMAIN
+from .utils import register_services
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -140,7 +141,8 @@ async def async_setup_entry(hass: HomeAssistant, entry):
     async def handle_manual_gps_update(call):
         _LOGGER.info("Manual GPS update requested.")
         await coordinator.async_request_refresh()
-    hass.services.async_register(DOMAIN, "update_gps", handle_manual_gps_update)
+
+    register_services(hass, DOMAIN, {"update_gps": handle_manual_gps_update})
 
     return True
 

--- a/custom_components/pawcontrol/health_system.py
+++ b/custom_components/pawcontrol/health_system.py
@@ -5,6 +5,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity, EntityCategory
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from .const import DOMAIN
+from .utils import register_services
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -80,15 +81,20 @@ async def async_setup_entry(hass: HomeAssistant, entry):
         details = call.data.get("details", {})
         logger.log_activity(activity_type, details)
 
-    hass.services.async_register(DOMAIN, "log_activity", handle_log_activity)
-
     async def handle_get_latest_activity(call):
         logger = get_activity_logger(hass)
         activity_type = call.data.get("type")
         latest = logger.get_latest(activity_type)
         _LOGGER.info("Latest activity: %s", latest)
 
-    hass.services.async_register(DOMAIN, "get_latest_activity", handle_get_latest_activity)
+    register_services(
+        hass,
+        DOMAIN,
+        {
+            "log_activity": handle_log_activity,
+            "get_latest_activity": handle_get_latest_activity,
+        },
+    )
 
     return True
 

--- a/custom_components/pawcontrol/installation_manager.py
+++ b/custom_components/pawcontrol/installation_manager.py
@@ -13,6 +13,7 @@ from .module_registry import (
     async_setup_modules,
     async_unload_modules,
 )
+from .utils import merge_entry_options
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,7 +24,7 @@ class InstallationManager:
     async def setup_entry(self, hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Set up the integration and selected modules."""
         # Merge config entry data and options, with options taking precedence
-        opts = entry.data | entry.options
+        opts = merge_entry_options(entry)
 
         # Some parts of the integration – especially helper creation – expect a
         # dog name to be present.  The title of the entry is the dog name in the

--- a/custom_components/pawcontrol/push.py
+++ b/custom_components/pawcontrol/push.py
@@ -1,6 +1,7 @@
 """Push-Modul für Paw Control – Service, Target-Handling, Setup/Teardown."""
 
 from .const import *
+from .utils import register_services
 
 async def setup_push(hass, entry):
     """Registriert Push-Service, Helper für Benachrichtigungen."""
@@ -25,7 +26,11 @@ async def setup_push(hass, entry):
             f"{dog}: {message}",
             title=title
         )
-    hass.services.async_register(DOMAIN, SERVICE_SEND_NOTIFICATION, handle_send_notification)
+    register_services(
+        hass,
+        DOMAIN,
+        {SERVICE_SEND_NOTIFICATION: handle_send_notification},
+    )
 
 async def teardown_push(hass, entry):
     """Entfernt Push-Service und zugehörige Helper."""

--- a/custom_components/pawcontrol/script_system.py
+++ b/custom_components/pawcontrol/script_system.py
@@ -16,6 +16,7 @@ from .const import (
     MEAL_TYPES,
     STATUS_MESSAGES,
 )
+from .utils import register_services
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -92,10 +93,7 @@ class PawControlScriptManager:
                 SERVICE_GENERATE_REPORT: self._generate_report_service,
             }
 
-            for service, handler in services.items():
-                self.hass.services.async_register(
-                    DOMAIN, service, handler, schema=None
-                )
+            register_services(self.hass, DOMAIN, services)
 
             _LOGGER.info(
                 "Registered %d services for %s", len(services), self._dog_name

--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -5,9 +5,10 @@ import re
 import logging
 from datetime import datetime, timedelta, timezone
 from math import radians, sin, cos, sqrt, atan2, isfinite
-from typing import List, Dict, Tuple, Optional, Any
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
 from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
 from homeassistant.util import slugify
 
@@ -27,6 +28,32 @@ _LOGGER = logging.getLogger(__name__)
 
 # Precompile dog name pattern for reuse
 DOG_NAME_RE = re.compile(DOG_NAME_PATTERN)
+
+
+def merge_entry_options(entry: ConfigEntry) -> dict[str, Any]:
+    """Merge config entry data and options.
+
+    Options take precedence over data. The returned dictionary is a new copy
+    so callers can modify it without affecting the original entry.
+    """
+
+    return {**entry.data, **entry.options}
+
+
+def register_services(
+    hass: HomeAssistant,
+    domain: str,
+    services: Mapping[str, Callable[..., Any]],
+) -> None:
+    """Register multiple service handlers for ``domain``.
+
+    ``services`` should be a mapping of service name to async handler function.
+    The handlers are registered with Home Assistant using
+    :func:`homeassistant.core.ServiceRegistry.async_register`.
+    """
+
+    for service, handler in services.items():
+        hass.services.async_register(domain, service, handler)
 
 
 def validate_dog_name(name: str) -> bool:

--- a/custom_components/pawcontrol/walk_system.py
+++ b/custom_components/pawcontrol/walk_system.py
@@ -10,6 +10,7 @@ from homeassistant.components.button import ButtonEntity
 from homeassistant.helpers.entity import Entity, EntityCategory
 
 from .const import DOMAIN
+from .utils import register_services
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -98,14 +99,15 @@ async def async_setup_entry(hass: HomeAssistant, _entry: ConfigEntry) -> bool:
         details = call.data.get("details", {})
         system.log_walk(timestamp, details)
 
-    hass.services.async_register(DOMAIN, "log_walk", handle_log_walk)
+    services = {"log_walk": handle_log_walk}
 
     async def handle_get_last_walk(_call: Any) -> None:
         system = get_walk_automation_system(hass)
         last_walk = system.get_last_walk()
         _LOGGER.info("Last walk: %s", last_walk)
 
-    hass.services.async_register(DOMAIN, "get_last_walk", handle_get_last_walk)
+    services["get_last_walk"] = handle_get_last_walk
+    register_services(hass, DOMAIN, services)
 
     return True
 


### PR DESCRIPTION
## Summary
- add helper to merge config entry data and options
- add service registration utility and apply across modules
- refactor script system and related modules to use helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68902ee041748331a38b027bb55e17f6