### PR TITLE
feat: enhance push notifications

### DIFF
--- a/custom_components/pawcontrol/push.py
+++ b/custom_components/pawcontrol/push.py
@@ -1,59 +1,92 @@
-"""Push-Modul für Paw Control – Service, Target-Handling, Setup/Teardown."""
+"""Push module for Paw Control – service, target handling, setup/teardown."""
 
-from .const import *
+from typing import Any, Optional
+
+from .const import CONF_DOG_NAME, DOMAIN, SERVICE_SEND_NOTIFICATION
 from .utils import register_services
 
+
+async def send_notification(
+    hass: Any,
+    dog: str,
+    helper_id: str,
+    message: str,
+    title: str,
+    target: Optional[str] = None,
+) -> None:
+    """Send a notification if the helper is active.
+
+    If ``target`` is provided, the ``notify`` service is used. Otherwise a
+    persistent notification is created. Notifications are only sent when the
+    ``input_boolean`` helper is in state ``on``.
+    """
+
+    helper_state = hass.states.get(helper_id)
+    if not helper_state or getattr(helper_state, "state", None) != "on":
+        return
+
+    payload = {"message": f"{dog}: {message}", "title": title}
+    if target:
+        await hass.services.async_call("notify", target, payload, blocking=True)
+    else:
+        hass.components.persistent_notification.create(
+            payload["message"], title=payload["title"]
+        )
+
+
 async def setup_push(hass, entry):
-    """Registriert Push-Service, Helper für Benachrichtigungen."""
+    """Register push service and helper for notifications."""
     dog = entry.data[CONF_DOG_NAME]
     helper_id = f"input_boolean.{dog}_push_active"
 
-    # Helper für Push-Benachrichtigungen anlegen (falls nicht vorhanden)
+    # Create helper if it doesn't exist yet
     if not hass.states.get(helper_id):
         await hass.services.async_call(
-            "input_boolean", "create",
+            "input_boolean",
+            "create",
             {"name": f"{dog} Push aktiviert", "entity_id": helper_id},
             blocking=True,
         )
 
-    # Service registrieren
+    # Register service
     async def handle_send_notification(call):
         message = call.data.get("message", "Aktion erforderlich!")
         title = call.data.get("title", f"Paw Control: {dog}")
-        target = call.data.get("target", None)
-        # Beispiel: persistent_notification (Push via App kannst du analog mit notify.notify machen)
-        hass.components.persistent_notification.create(
-            f"{dog}: {message}",
-            title=title
-        )
+        target = call.data.get("target")
+        await send_notification(hass, dog, helper_id, message, title, target)
+
     register_services(
         hass,
         DOMAIN,
         {SERVICE_SEND_NOTIFICATION: handle_send_notification},
     )
 
+
 async def teardown_push(hass, entry):
-    """Entfernt Push-Service und zugehörige Helper."""
+    """Remove push service and associated helpers."""
     dog = entry.data[CONF_DOG_NAME]
     helper_id = f"input_boolean.{dog}_push_active"
-    # Helper entfernen
+    # Remove helper
     if hass.states.get(helper_id):
         await hass.services.async_call(
-            "input_boolean", "remove",
+            "input_boolean",
+            "remove",
             {"entity_id": helper_id},
             blocking=True,
         )
-    # Service deregistrieren
+    # Deregister service
     if hass.services.has_service(DOMAIN, SERVICE_SEND_NOTIFICATION):
         hass.services.async_remove(DOMAIN, SERVICE_SEND_NOTIFICATION)
 
+
 async def ensure_helpers(hass, opts):
-    """Stellt sicher, dass Push-Helper existieren."""
+    """Ensure that push helpers exist."""
     dog = opts[CONF_DOG_NAME]
     helper_id = f"input_boolean.{dog}_push_active"
     if not hass.states.get(helper_id):
         await hass.services.async_call(
-            "input_boolean", "create",
+            "input_boolean",
+            "create",
             {"name": f"{dog} Push aktiviert", "entity_id": helper_id},
             blocking=True,
         )

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -1,0 +1,63 @@
+import asyncio
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+sys.path.insert(0, os.path.abspath("."))
+
+from custom_components.pawcontrol.push import send_notification
+
+
+def _hass(states_state="on"):
+    return SimpleNamespace(
+        states=SimpleNamespace(get=lambda _: SimpleNamespace(state=states_state)),
+        services=SimpleNamespace(async_call=AsyncMock()),
+        components=SimpleNamespace(
+            persistent_notification=SimpleNamespace(create=Mock())
+        ),
+    )
+
+
+def test_send_notification_helper_off():
+    async def run_test():
+        hass = _hass(states_state="off")
+        await send_notification(hass, "Buddy", "input_boolean.Buddy_push_active", "Hi", "Title")
+        hass.services.async_call.assert_not_called()
+        hass.components.persistent_notification.create.assert_not_called()
+    asyncio.run(run_test())
+
+
+def test_send_notification_with_target_calls_notify():
+    async def run_test():
+        hass = _hass()
+        await send_notification(
+            hass,
+            "Buddy",
+            "input_boolean.Buddy_push_active",
+            "Hello",
+            "Title",
+            "mobile",
+        )
+        hass.services.async_call.assert_called_once_with(
+            "notify", "mobile", {"message": "Buddy: Hello", "title": "Title"}, blocking=True
+        )
+        hass.components.persistent_notification.create.assert_not_called()
+    asyncio.run(run_test())
+
+
+def test_send_notification_without_target_creates_persistent_notification():
+    async def run_test():
+        hass = _hass()
+        await send_notification(
+            hass,
+            "Buddy",
+            "input_boolean.Buddy_push_active",
+            "Hello",
+            "Title",
+        )
+        hass.components.persistent_notification.create.assert_called_once_with(
+            "Buddy: Hello", title="Title"
+        )
+        hass.services.async_call.assert_not_called()
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- send push notifications only when enabled helper is on
- allow targeted notify service or persistent fallback
- add coverage for push notifications

## Testing
- `pytest`
- `pytest tests/test_push.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68903f1778648331ac8e50014a1f5b5c