### PR TITLE
Add base classes for GPS and health entities

### DIFF
--- a/custom_components/pawcontrol/entities/gps.py
+++ b/custom_components/pawcontrol/entities/gps.py
@@ -1,15 +1,14 @@
 """Gemeinsame GPS-Basisklasse für alle Paw Control GPS-Entities."""
 
-from homeassistant.helpers.entity import Entity
+from .base import PawControlBaseEntity
 from ..helpers.gps import is_valid_gps_coords
 
-class PawControlGpsEntity(Entity):
-    """Basisklasse für GPS-Entities."""
 
-    def __init__(self, name, coordinator):
-        self._attr_name = name
-        self._coordinator = coordinator
-        self._state = None
+class PawControlGpsEntity(PawControlBaseEntity):
+    """Basisklasse für GPS-Entities mit gemeinsamer Update-Logik."""
+
+    def __init__(self, coordinator, name):
+        super().__init__(coordinator, name)
 
     @property
     def available(self):
@@ -17,9 +16,8 @@ class PawControlGpsEntity(Entity):
         data = self._coordinator.data.get(self._attr_name, {})
         return is_valid_gps_coords(data.get("lat"), data.get("lon"))
 
-    async def async_update(self):
-        """Daten beim Coordinator aktualisieren."""
-        await self._coordinator.async_request_refresh()
+    def _update_state(self):
+        """Aktualisiere internen State mit gültigen Koordinaten."""
         data = self._coordinator.data.get(self._attr_name, {})
         if is_valid_gps_coords(data.get("lat"), data.get("lon")):
             self._state = (data["lat"], data["lon"])

--- a/custom_components/pawcontrol/entities/health.py
+++ b/custom_components/pawcontrol/entities/health.py
@@ -1,0 +1,23 @@
+"""Gemeinsame Basisklasse für Health-bezogene Entities."""
+
+from homeassistant.helpers.entity import Entity
+from ..const import DOMAIN
+
+
+class PawControlHealthEntity(Entity):
+    """Basisklasse für Health-Überwachungs-Entities."""
+
+    def __init__(self, activity_logger, entry_id: str, name: str, suffix: str) -> None:
+        self._activity_logger = activity_logger
+        self._attr_name = name
+        self._attr_unique_id = f"{DOMAIN}_{suffix}_{entry_id}"
+
+    @property
+    def _latest_health(self):
+        """Gibt den letzten Health-Eintrag zurück."""
+        return self._activity_logger.get_latest("health")
+
+    @property
+    def extra_state_attributes(self):
+        """Standard-Attribute enthalten den letzten Health-Eintrag."""
+        return self._latest_health or {}


### PR DESCRIPTION
## Summary
- share common GPS update logic via a `PawControlGpsEntity` base class
- introduce `PawControlHealthEntity` for health monitoring entities and refactor health sensors to use it

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68904177c6b48331961da90084fe20b8