### PR TITLE
feat: expand entity base classes with helper validation

### DIFF
--- a/custom_components/pawcontrol/const.py
+++ b/custom_components/pawcontrol/const.py
@@ -36,6 +36,8 @@ ATTR_LAST_EVENT = "last_event"
 ATTR_DASHBOARD_VIEW = "dashboard_view"
 ATTR_EVENT_TYPE = "event_type"
 ATTR_EVENT_DETAIL = "event_detail"
+ATTR_DOG_NAME = "dog_name"
+ATTR_LAST_UPDATED = "last_updated"
 
 # Standardwerte
 DEFAULT_FEEDING_TIMES = []

--- a/custom_components/pawcontrol/entities/device_tracker.py
+++ b/custom_components/pawcontrol/entities/device_tracker.py
@@ -1,17 +1,37 @@
 # entities/device_tracker.py
 from homeassistant.components.device_tracker import TrackerEntity
+
 from .base import PawControlBaseEntity
+from ..helpers.gps import format_gps_coords, is_valid_gps_coords
+
 
 class PawControlDeviceTrackerEntity(PawControlBaseEntity, TrackerEntity):
-    """Basisklasse für Device Tracker-Entities."""
+    """Basisklasse für Device Tracker-Entities mit Koordinatenvalidierung."""
+
+    def _update_state(self) -> None:
+        """Aktualisiere den internen GPS-Status."""
+        data = self.coordinator.data.get(self._attr_name, {})
+        lat = data.get("lat")
+        lon = data.get("lon")
+        if is_valid_gps_coords(lat, lon):
+            self._state = {"lat": lat, "lon": lon}
+        else:
+            self._state = None
 
     @property
     def latitude(self):
-        return self._state.get("lat") if self._state else None
+        return self._state["lat"] if self._state else None
 
     @property
     def longitude(self):
-        return self._state.get("lon") if self._state else None
+        return self._state["lon"] if self._state else None
+
+    @property
+    def extra_state_attributes(self):
+        attrs = super().extra_state_attributes
+        if self._state:
+            attrs["coords"] = format_gps_coords(self.latitude, self.longitude)
+        return attrs
 
     @property
     def source_type(self):

--- a/custom_components/pawcontrol/entities/number.py
+++ b/custom_components/pawcontrol/entities/number.py
@@ -1,14 +1,29 @@
 # entities/number.py
 from homeassistant.components.number import NumberEntity
+
 from .base import PawControlBaseEntity
+from ..helpers.entity import clamp_value
 
 class PawControlNumberEntity(PawControlBaseEntity, NumberEntity):
-    """Basisklasse für Number-Entities."""
+    """Basisklasse für Number-Entities mit Validierung."""
+
+    def __init__(
+        self,
+        coordinator,
+        name: str,
+        dog_name: str | None = None,
+        unique_suffix: str | None = None,
+        min_value: float | None = None,
+        max_value: float | None = None,
+    ) -> None:
+        super().__init__(coordinator, name, dog_name, unique_suffix)
+        self._attr_native_min_value = min_value
+        self._attr_native_max_value = max_value
 
     @property
-    def value(self):
+    def native_value(self):
         return self._state
 
-    async def async_set_value(self, value: float):
-        # Wert setzen
-        pass
+    async def async_set_native_value(self, value: float) -> None:
+        """Setze den numerischen Wert innerhalb der Grenzen."""
+        self._state = clamp_value(value, self.native_min_value, self.native_max_value)

--- a/custom_components/pawcontrol/entities/select.py
+++ b/custom_components/pawcontrol/entities/select.py
@@ -1,19 +1,33 @@
 # entities/select.py
 from homeassistant.components.select import SelectEntity
+
 from .base import PawControlBaseEntity
+from ..helpers.entity import ensure_option
 
 class PawControlSelectEntity(PawControlBaseEntity, SelectEntity):
-    """Basisklasse für Select-Entities."""
+    """Basisklasse für Select-Entities mit Validierung."""
+
+    def __init__(
+        self,
+        coordinator,
+        name: str,
+        dog_name: str | None = None,
+        unique_suffix: str | None = None,
+        options: list[str] | None = None,
+    ) -> None:
+        super().__init__(coordinator, name, dog_name, unique_suffix)
+        self._attr_options = options or []
+        if self._attr_options:
+            self._state = self._attr_options[0]
 
     @property
     def current_option(self):
         return self._state
 
     async def async_select_option(self, option: str):
-        # Option setzen
-        pass
+        """Wähle eine Option aus der Optionsliste."""
+        self._state = ensure_option(option, self.options)
 
     @property
     def options(self):
-        # Rückgabe der verfügbaren Optionen
-        return []
+        return self._attr_options

--- a/custom_components/pawcontrol/helpers/__init__.py
+++ b/custom_components/pawcontrol/helpers/__init__.py
@@ -1,0 +1,2 @@
+"""Helper-Module für Paw Control Entities."""
+

--- a/custom_components/pawcontrol/helpers/entity.py
+++ b/custom_components/pawcontrol/helpers/entity.py
@@ -43,3 +43,21 @@ def clamp_string(value: str | None, max_length: int) -> str:
         return ""
     return str(value)[:max_length]
 
+
+def clamp_value(
+    value: float, min_value: float | None = None, max_value: float | None = None
+) -> float:
+    """Begrenze einen numerischen Wert auf einen Bereich."""
+    if min_value is not None and value < min_value:
+        return min_value
+    if max_value is not None and value > max_value:
+        return max_value
+    return value
+
+
+def ensure_option(option: str, options: list[str]) -> str:
+    """Validiere eine Auswahl gegen eine Optionsliste."""
+    if option in options:
+        return option
+    return options[0] if options else option
+

--- a/tests/test_entity_helpers.py
+++ b/tests/test_entity_helpers.py
@@ -1,0 +1,21 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("."))
+
+from custom_components.pawcontrol.helpers.entity import clamp_value, ensure_option
+
+
+def test_clamp_value():
+    assert clamp_value(5, 0, 10) == 5
+    assert clamp_value(-1, 0, 10) == 0
+    assert clamp_value(11, 0, 10) == 10
+
+
+def test_ensure_option():
+    options = ["a", "b"]
+    assert ensure_option("b", options) == "b"
+    assert ensure_option("c", options) == "a"
+    assert ensure_option("c", []) == "c"


### PR DESCRIPTION
## Summary
- extend entity helpers with generic validators
- use helpers across number, select and tracker base entities
- expose helper package and add tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890480507e48331b2bc0b603411fcf1