### PR TITLE
feat: add reusable entity base classes

### DIFF
--- a/custom_components/pawcontrol/entities/__init__.py
+++ b/custom_components/pawcontrol/entities/__init__.py
@@ -1,0 +1,29 @@
+"""Hilfspaket mit Basis-Entity-Klassen für Paw Control."""
+
+from .base import PawControlBaseEntity
+from .binary_sensor import PawControlBinarySensorEntity
+from .button import PawControlButtonEntity
+from .datetime import PawControlDateTimeEntity
+from .device_tracker import PawControlDeviceTrackerEntity
+from .gps import PawControlGpsEntity
+from .health import PawControlHealthEntity
+from .number import PawControlNumberEntity
+from .select import PawControlSelectEntity
+from .sensor import PawControlSensorEntity
+from .switch import PawControlSwitchEntity
+from .text import PawControlTextEntity
+
+__all__ = [
+    "PawControlBaseEntity",
+    "PawControlBinarySensorEntity",
+    "PawControlButtonEntity",
+    "PawControlDateTimeEntity",
+    "PawControlDeviceTrackerEntity",
+    "PawControlGpsEntity",
+    "PawControlHealthEntity",
+    "PawControlNumberEntity",
+    "PawControlSelectEntity",
+    "PawControlSensorEntity",
+    "PawControlSwitchEntity",
+    "PawControlTextEntity",
+]

--- a/tests/test_entity_base_classes.py
+++ b/tests/test_entity_base_classes.py
@@ -1,0 +1,59 @@
+import os
+import sys
+from datetime import datetime
+
+import asyncio
+
+sys.path.insert(0, os.path.abspath("."))
+
+from custom_components.pawcontrol.entities.text import PawControlTextEntity
+from custom_components.pawcontrol.entities.number import PawControlNumberEntity
+from custom_components.pawcontrol.entities.select import PawControlSelectEntity
+from custom_components.pawcontrol.entities.datetime import PawControlDateTimeEntity
+
+
+class DummyCoordinator:
+    def __init__(self, data=None):
+        self.data = data or {}
+
+    async def async_request_refresh(self):
+        return None
+
+
+def test_text_entity_clamps_value():
+    entity = PawControlTextEntity(DummyCoordinator(), "Name", dog_name="Bello", unique_suffix="name", max_length=5)
+    asyncio.run(entity.async_set_value("abcdefgh"))
+    assert entity.native_value == "abcde"
+
+
+def test_number_entity_clamps_value():
+    entity = PawControlNumberEntity(
+        DummyCoordinator(), "Level", dog_name="Bello", unique_suffix="level", min_value=0, max_value=10
+    )
+    asyncio.run(entity.async_set_native_value(15))
+    assert entity.native_value == 10
+    asyncio.run(entity.async_set_native_value(-5))
+    assert entity.native_value == 0
+
+
+def test_select_entity_validates_option():
+    entity = PawControlSelectEntity(
+        DummyCoordinator(), "Mode", dog_name="Bello", unique_suffix="mode", options=["a", "b"]
+    )
+    asyncio.run(entity.async_select_option("c"))
+    assert entity.current_option == "a"
+    asyncio.run(entity.async_select_option("b"))
+    assert entity.current_option == "b"
+
+
+def test_datetime_entity_converts_value():
+    coordinator = DummyCoordinator({"Time": "2023-10-10T10:00:00+00:00"})
+    entity = PawControlDateTimeEntity(coordinator, "Time")
+    entity._update_state()
+    value = entity.native_value
+    assert isinstance(value, datetime)
+    assert value.year == 2023
+    assert value.month == 10
+    assert value.day == 10
+    assert value.hour == 10
+    assert value.minute == 0


### PR DESCRIPTION
## Summary
- expose shared entity base classes through an `entities` package
- test entity helpers for clamping, validation, and conversion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68904ea03b748331942fdf2ca65786cd