### PR TITLE
feat: add bool conversion helper for entities

### DIFF
--- a/custom_components/pawcontrol/entities/binary_sensor.py
+++ b/custom_components/pawcontrol/entities/binary_sensor.py
@@ -1,10 +1,17 @@
 # entities/binary_sensor.py
 from homeassistant.components.binary_sensor import BinarySensorEntity
+
 from .base import PawControlBaseEntity
+from ..helpers.entity import as_bool
+
 
 class PawControlBinarySensorEntity(PawControlBaseEntity, BinarySensorEntity):
-    """Basisklasse für Binary Sensor-Entities."""
+    """Basisklasse für Binary Sensor-Entities mit Konvertierung."""
+
+    def _update_state(self) -> None:
+        """Hole und konvertiere den Status aus den Koordinatordaten."""
+        self._state = as_bool(self.coordinator.data.get(self._attr_name))
 
     @property
-    def is_on(self):
-        return bool(self._state)
+    def is_on(self) -> bool:
+        return self._state

--- a/custom_components/pawcontrol/entities/switch.py
+++ b/custom_components/pawcontrol/entities/switch.py
@@ -1,13 +1,20 @@
 # entities/switch.py
 from homeassistant.components.switch import SwitchEntity
+
 from .base import PawControlBaseEntity
+from ..helpers.entity import as_bool
+
 
 class PawControlSwitchEntity(PawControlBaseEntity, SwitchEntity):
-    """Basisklasse für Switch-Entities."""
+    """Basisklasse für Switch-Entities mit boolescher Konvertierung."""
+
+    def _update_state(self) -> None:
+        """Hole und konvertiere den Status aus den Koordinatordaten."""
+        self._state = as_bool(self.coordinator.data.get(self._attr_name))
 
     @property
-    def is_on(self):
-        return bool(self._state)
+    def is_on(self) -> bool:
+        return self._state
 
     async def async_turn_on(self, **kwargs):
         # Geräte einschalten

--- a/custom_components/pawcontrol/helpers/entity.py
+++ b/custom_components/pawcontrol/helpers/entity.py
@@ -61,3 +61,12 @@ def ensure_option(option: str, options: list[str]) -> str:
         return option
     return options[0] if options else option
 
+
+def as_bool(value: Any) -> bool:
+    """Konvertiere verschiedene Darstellungen zu einem booleschen Wert."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.lower() in ("true", "on", "1", "yes")
+    return bool(value)
+

--- a/tests/test_entity_base_classes.py
+++ b/tests/test_entity_base_classes.py
@@ -6,10 +6,13 @@ import asyncio
 
 sys.path.insert(0, os.path.abspath("."))
 
-from custom_components.pawcontrol.entities.text import PawControlTextEntity
+from custom_components.pawcontrol.entities.binary_sensor import (
+    PawControlBinarySensorEntity,
+)
+from custom_components.pawcontrol.entities.datetime import PawControlDateTimeEntity
 from custom_components.pawcontrol.entities.number import PawControlNumberEntity
 from custom_components.pawcontrol.entities.select import PawControlSelectEntity
-from custom_components.pawcontrol.entities.datetime import PawControlDateTimeEntity
+from custom_components.pawcontrol.entities.text import PawControlTextEntity
 
 
 class DummyCoordinator:
@@ -57,3 +60,15 @@ def test_datetime_entity_converts_value():
     assert value.day == 10
     assert value.hour == 10
     assert value.minute == 0
+
+
+def test_binary_sensor_converts_value():
+    coordinator = DummyCoordinator({"Door": "on"})
+    entity = PawControlBinarySensorEntity(coordinator, "Door")
+    entity._update_state()
+    assert entity.is_on is True
+
+    coordinator = DummyCoordinator({"Door": "off"})
+    entity = PawControlBinarySensorEntity(coordinator, "Door")
+    entity._update_state()
+    assert entity.is_on is False

--- a/tests/test_entity_helpers.py
+++ b/tests/test_entity_helpers.py
@@ -5,7 +5,11 @@ import pytest
 
 sys.path.insert(0, os.path.abspath("."))
 
-from custom_components.pawcontrol.helpers.entity import clamp_value, ensure_option
+from custom_components.pawcontrol.helpers.entity import (
+    as_bool,
+    clamp_value,
+    ensure_option,
+)
 
 
 def test_clamp_value():
@@ -19,3 +23,10 @@ def test_ensure_option():
     assert ensure_option("b", options) == "b"
     assert ensure_option("c", options) == "a"
     assert ensure_option("c", []) == "c"
+
+
+def test_as_bool():
+    assert as_bool(True) is True
+    assert as_bool("on") is True
+    assert as_bool("off") is False
+    assert as_bool(0) is False


### PR DESCRIPTION
## Summary
- add `as_bool` helper for consistent boolean conversion
- use helper in base binary sensor and switch entities
- cover helper and entities with unit tests

## Testing
- `pytest tests/test_entity_helpers.py tests/test_entity_base_classes.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689051e7d0e88331b5aef6f2e07df6e0