### PR TITLE
refactor: use shared entity bases

### DIFF
--- a/custom_components/pawcontrol/binary_sensor.py
+++ b/custom_components/pawcontrol/binary_sensor.py
@@ -5,17 +5,14 @@ import logging
 from datetime import datetime, timedelta
 from typing import Any
 
-from homeassistant.components.binary_sensor import (
-    BinarySensorDeviceClass,
-    BinarySensorEntity,
-)
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, ICONS, ATTR_DOG_NAME, ATTR_LAST_UPDATED
+from .const import DOMAIN, ICONS
 from .coordinator import PawControlCoordinator
+from .entities import PawControlBinarySensorEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,8 +40,8 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class PawControlBinarySensorBase(CoordinatorEntity, BinarySensorEntity):
-    """Base class for Paw Control binary sensors."""
+class PawControlBinarySensorBase(PawControlBinarySensorEntity):
+    """Gemeinsame Basis für Paw Control Binary Sensors."""
 
     def __init__(
         self,
@@ -52,31 +49,9 @@ class PawControlBinarySensorBase(CoordinatorEntity, BinarySensorEntity):
         dog_name: str,
         sensor_type: str,
     ) -> None:
-        """Initialize the binary sensor."""
-        super().__init__(coordinator)
-        self._dog_name = dog_name
-        self._sensor_type = sensor_type
-        self._attr_unique_id = f"{DOMAIN}_{dog_name.lower()}_{sensor_type}"
-        self._attr_name = f"{dog_name} {sensor_type.replace('_', ' ').title()}"
-
-    @property
-    def device_info(self) -> dict[str, Any]:
-        """Return device information."""
-        return {
-            "identifiers": {(DOMAIN, self._dog_name.lower())},
-            "name": f"Paw Control - {self._dog_name}",
-            "manufacturer": "Paw Control",
-            "model": "Dog Management System",
-            "sw_version": "1.0.0",
-        }
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        """Return extra state attributes."""
-        return {
-            ATTR_DOG_NAME: self._dog_name,
-            ATTR_LAST_UPDATED: datetime.now().isoformat(),
-        }
+        """Initialisiere den Binary Sensor mit Standardattributen."""
+        name = f"{dog_name} {sensor_type.replace('_', ' ').title()}"
+        super().__init__(coordinator, name, dog_name, sensor_type)
 
 
 class PawControlIsHungryBinarySensor(PawControlBinarySensorBase):

--- a/custom_components/pawcontrol/button.py
+++ b/custom_components/pawcontrol/button.py
@@ -3,16 +3,14 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
-from typing import Any
 
-from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, ICONS, ATTR_DOG_NAME, ATTR_LAST_UPDATED
+from .const import DOMAIN, ICONS
 from .coordinator import PawControlCoordinator
+from .entities import PawControlButtonEntity
 from .utils import safe_service_call
 
 _LOGGER = logging.getLogger(__name__)
@@ -48,8 +46,8 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class PawControlButtonBase(CoordinatorEntity, ButtonEntity):
-    """Base class for Paw Control buttons."""
+class PawControlButtonBase(PawControlButtonEntity):
+    """Gemeinsame Basis für Paw Control Buttons."""
 
     def __init__(
         self,
@@ -57,31 +55,9 @@ class PawControlButtonBase(CoordinatorEntity, ButtonEntity):
         dog_name: str,
         button_type: str,
     ) -> None:
-        """Initialize the button."""
-        super().__init__(coordinator)
-        self._dog_name = dog_name
-        self._button_type = button_type
-        self._attr_unique_id = f"{DOMAIN}_{dog_name.lower()}_{button_type}"
-        self._attr_name = f"{dog_name} {button_type.replace('_', ' ').title()}"
-
-    @property
-    def device_info(self) -> dict[str, Any]:
-        """Return device information."""
-        return {
-            "identifiers": {(DOMAIN, self._dog_name.lower())},
-            "name": f"Paw Control - {self._dog_name}",
-            "manufacturer": "Paw Control",
-            "model": "Dog Management System",
-            "sw_version": "1.0.0",
-        }
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        """Return extra state attributes."""
-        return {
-            ATTR_DOG_NAME: self._dog_name,
-            ATTR_LAST_UPDATED: datetime.now().isoformat(),
-        }
+        """Initialisiere den Button mit Standardattributen."""
+        name = f"{dog_name} {button_type.replace('_', ' ').title()}"
+        super().__init__(coordinator, name, dog_name, button_type)
 
     async def _safe_service_call(self, domain: str, service: str, data: dict) -> bool:
         """Safely call a service with consistent error handling."""

--- a/custom_components/pawcontrol/health_system.py
+++ b/custom_components/pawcontrol/health_system.py
@@ -7,7 +7,7 @@ from homeassistant.components.binary_sensor import BinarySensorEntity
 
 from .const import DOMAIN
 from .utils import register_services
-from .entities.health import PawControlHealthEntity
+from .entities import PawControlHealthEntity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/pawcontrol/sensor.py
+++ b/custom_components/pawcontrol/sensor.py
@@ -5,14 +5,14 @@ import logging
 from datetime import datetime
 from typing import Any
 
-from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
+from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, ICONS, ATTR_DOG_NAME, ATTR_LAST_UPDATED
+from .const import DOMAIN, ICONS
 from .coordinator import PawControlCoordinator
+from .entities import PawControlSensorEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -47,8 +47,8 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class PawControlSensorBase(CoordinatorEntity, SensorEntity):
-    """Base class for Paw Control sensors."""
+class PawControlSensorBase(PawControlSensorEntity):
+    """Gemeinsame Basis für Paw Control Sensoren."""
 
     def __init__(
         self,
@@ -56,31 +56,9 @@ class PawControlSensorBase(CoordinatorEntity, SensorEntity):
         dog_name: str,
         sensor_type: str,
     ) -> None:
-        """Initialize the sensor."""
-        super().__init__(coordinator)
-        self._dog_name = dog_name
-        self._sensor_type = sensor_type
-        self._attr_unique_id = f"{DOMAIN}_{dog_name.lower()}_{sensor_type}"
-        self._attr_name = f"{dog_name} {sensor_type.replace('_', ' ').title()}"
-
-    @property
-    def device_info(self) -> dict[str, Any]:
-        """Return device information."""
-        return {
-            "identifiers": {(DOMAIN, self._dog_name.lower())},
-            "name": f"Paw Control - {self._dog_name}",
-            "manufacturer": "Paw Control",
-            "model": "Dog Management System",
-            "sw_version": "1.0.0",
-        }
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        """Return extra state attributes."""
-        return {
-            ATTR_DOG_NAME: self._dog_name,
-            ATTR_LAST_UPDATED: datetime.now().isoformat(),
-        }
+        """Initialisiere den Sensor mit Standardattributen."""
+        name = f"{dog_name} {sensor_type.replace('_', ' ').title()}"
+        super().__init__(coordinator, name, dog_name, sensor_type)
 
 
 class PawControlStatusSensor(PawControlSensorBase):

--- a/custom_components/pawcontrol/switch.py
+++ b/custom_components/pawcontrol/switch.py
@@ -5,14 +5,13 @@ import logging
 from datetime import datetime
 from typing import Any
 
-from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, ICONS, ATTR_DOG_NAME, ATTR_LAST_UPDATED
+from .const import DOMAIN, ICONS
 from .coordinator import PawControlCoordinator
+from .entities import PawControlSwitchEntity
 from .utils import safe_service_call
 
 _LOGGER = logging.getLogger(__name__)
@@ -46,8 +45,8 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class PawControlSwitchBase(CoordinatorEntity, SwitchEntity):
-    """Base class for Paw Control switches."""
+class PawControlSwitchBase(PawControlSwitchEntity):
+    """Gemeinsame Basis für Paw Control Switches."""
 
     def __init__(
         self,
@@ -55,31 +54,9 @@ class PawControlSwitchBase(CoordinatorEntity, SwitchEntity):
         dog_name: str,
         switch_type: str,
     ) -> None:
-        """Initialize the switch."""
-        super().__init__(coordinator)
-        self._dog_name = dog_name
-        self._switch_type = switch_type
-        self._attr_unique_id = f"{DOMAIN}_{dog_name.lower()}_{switch_type}"
-        self._attr_name = f"{dog_name.title()} {switch_type.replace('_', ' ').title()}"
-
-    @property
-    def device_info(self) -> dict[str, Any]:
-        """Return device information."""
-        return {
-            "identifiers": {(DOMAIN, self._dog_name.lower())},
-            "name": f"Paw Control - {self._dog_name}",
-            "manufacturer": "Paw Control",
-            "model": "Dog Management System",
-            "sw_version": "1.0.0",
-        }
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        """Return extra state attributes."""
-        return {
-            ATTR_DOG_NAME: self._dog_name,
-            ATTR_LAST_UPDATED: datetime.now().isoformat(),
-        }
+        """Initialisiere den Switch mit Standardattributen."""
+        name = f"{dog_name.title()} {switch_type.replace('_', ' ').title()}"
+        super().__init__(coordinator, name, dog_name, switch_type)
 
     async def _safe_service_call(self, domain: str, service: str, data: dict) -> bool:
         """Safely call a service with consistent error handling."""

--- a/tests/test_entity_base_classes.py
+++ b/tests/test_entity_base_classes.py
@@ -6,13 +6,22 @@ import asyncio
 
 sys.path.insert(0, os.path.abspath("."))
 
-from custom_components.pawcontrol.entities.binary_sensor import (
-    PawControlBinarySensorEntity,
+from custom_components.pawcontrol.const import (
+    ATTR_DOG_NAME,
+    ATTR_LAST_UPDATED,
+    DOMAIN,
 )
-from custom_components.pawcontrol.entities.datetime import PawControlDateTimeEntity
-from custom_components.pawcontrol.entities.number import PawControlNumberEntity
-from custom_components.pawcontrol.entities.select import PawControlSelectEntity
-from custom_components.pawcontrol.entities.text import PawControlTextEntity
+from custom_components.pawcontrol.entities import (
+    PawControlBaseEntity,
+    PawControlBinarySensorEntity,
+    PawControlButtonEntity,
+    PawControlDateTimeEntity,
+    PawControlNumberEntity,
+    PawControlSelectEntity,
+    PawControlSensorEntity,
+    PawControlSwitchEntity,
+    PawControlTextEntity,
+)
 
 
 class DummyCoordinator:
@@ -62,13 +71,62 @@ def test_datetime_entity_converts_value():
     assert value.minute == 0
 
 
-def test_binary_sensor_converts_value():
+def test_binary_sensor_inherits_attributes_and_converts():
     coordinator = DummyCoordinator({"Door": "on"})
-    entity = PawControlBinarySensorEntity(coordinator, "Door")
+    entity = PawControlBinarySensorEntity(
+        coordinator, "Door", dog_name="Bello", unique_suffix="door"
+    )
     entity._update_state()
     assert entity.is_on is True
+    assert entity.unique_id == f"{DOMAIN}_bello_door"
+    assert entity.device_info["name"] == "Paw Control - Bello"
+    attrs = entity.extra_state_attributes
+    assert attrs[ATTR_DOG_NAME] == "Bello"
+    assert ATTR_LAST_UPDATED in attrs
 
     coordinator = DummyCoordinator({"Door": "off"})
-    entity = PawControlBinarySensorEntity(coordinator, "Door")
+    entity = PawControlBinarySensorEntity(
+        coordinator, "Door", dog_name="Bello", unique_suffix="door"
+    )
     entity._update_state()
     assert entity.is_on is False
+
+
+def test_sensor_entity_inherits_state_and_device_info():
+    coordinator = DummyCoordinator({"Temp": 25})
+    entity = PawControlSensorEntity(
+        coordinator, "Temp", dog_name="Bello", unique_suffix="temp"
+    )
+    entity._update_state()
+    assert entity.state == 25
+    assert entity.unique_id == f"{DOMAIN}_bello_temp"
+    assert entity.device_info["name"] == "Paw Control - Bello"
+    attrs = entity.extra_state_attributes
+    assert attrs[ATTR_DOG_NAME] == "Bello"
+    assert ATTR_LAST_UPDATED in attrs
+
+
+def test_switch_entity_inherits_attributes_and_converts():
+    coordinator = DummyCoordinator({"Light": "true"})
+    entity = PawControlSwitchEntity(
+        coordinator, "Light", dog_name="Bello", unique_suffix="light"
+    )
+    entity._update_state()
+    assert entity.is_on is True
+    assert entity.unique_id == f"{DOMAIN}_bello_light"
+    assert entity.device_info["name"] == "Paw Control - Bello"
+    attrs = entity.extra_state_attributes
+    assert attrs[ATTR_DOG_NAME] == "Bello"
+    assert ATTR_LAST_UPDATED in attrs
+
+
+def test_button_entity_has_device_info_and_attributes():
+    entity = PawControlButtonEntity(
+        DummyCoordinator(), "Feed", dog_name="Bello", unique_suffix="feed"
+    )
+    assert isinstance(entity, PawControlBaseEntity)
+    assert entity.unique_id == f"{DOMAIN}_bello_feed"
+    assert entity.device_info["name"] == "Paw Control - Bello"
+    attrs = entity.extra_state_attributes
+    assert attrs[ATTR_DOG_NAME] == "Bello"
+    assert ATTR_LAST_UPDATED in attrs


### PR DESCRIPTION
## Summary
- refactor sensor platforms to subclass shared entity base classes
- centralize device info and attribute handling through entity helpers
- add tests ensuring platform entities inherit standard attributes and device info from shared bases
- standardize health system import to the shared entities module

## Testing
- `pip install pre-commit` *(failed: Could not find a version that satisfies the requirement pre-commit (ProxyError: Tunnel connection failed: 403 Forbidden))*
- `pre-commit run --files custom_components/pawcontrol/health_system.py` *(command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890546b0f9c833197dcbdb7fc2e0e37