### PR TITLE
feat: add entity base classes with helper-powered attributes

### DIFF
--- a/custom_components/pawcontrol/entities/base.py
+++ b/custom_components/pawcontrol/entities/base.py
@@ -61,7 +61,7 @@ class PawControlBaseEntity(CoordinatorEntity):
         """Zusätzliche Attribute für den Entity-State."""
         if not self._dog_name:
             return {}
-        return build_attributes(self._dog_name)
+        return self.build_extra_attributes()
 
     def build_extra_attributes(self, **extra: Any) -> dict[str, Any]:
         """Hilfsfunktion für Unterklassen zur Attribut-Erstellung."""

--- a/custom_components/pawcontrol/entities/device_tracker.py
+++ b/custom_components/pawcontrol/entities/device_tracker.py
@@ -28,10 +28,11 @@ class PawControlDeviceTrackerEntity(PawControlBaseEntity, TrackerEntity):
 
     @property
     def extra_state_attributes(self):
-        attrs = super().extra_state_attributes
         if self._state:
-            attrs["coords"] = format_gps_coords(self.latitude, self.longitude)
-        return attrs
+            return self.build_extra_attributes(
+                coords=format_gps_coords(self.latitude, self.longitude)
+            )
+        return super().extra_state_attributes
 
     @property
     def source_type(self):

--- a/custom_components/pawcontrol/entities/gps.py
+++ b/custom_components/pawcontrol/entities/gps.py
@@ -24,3 +24,10 @@ class PawControlGpsEntity(PawControlBaseEntity):
             self._state = (data["lat"], data["lon"])
         else:
             self._state = None
+
+    @property
+    def extra_state_attributes(self):
+        if self._state:
+            lat, lon = self._state
+            return self.build_extra_attributes(lat=lat, lon=lon)
+        return super().extra_state_attributes


### PR DESCRIPTION
## Summary
- centralize attribute building in `PawControlBaseEntity`
- use entity helper utilities for device tracker and GPS attributes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68905ae2a8088331957c5ca7fd6a78fa