### PR TITLE
refactor: centralize entity setup

### DIFF
--- a/custom_components/pawcontrol/entities/base.py
+++ b/custom_components/pawcontrol/entities/base.py
@@ -7,7 +7,7 @@ from typing import Any
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ..const import DOMAIN
-from ..helpers.entity import build_attributes
+from ..helpers.entity import build_attributes, format_name, get_icon
 
 
 class PawControlBaseEntity(CoordinatorEntity):
@@ -16,11 +16,19 @@ class PawControlBaseEntity(CoordinatorEntity):
     def __init__(
         self,
         coordinator,
-        name: str,
+        name: str | None = None,
         dog_name: str | None = None,
         unique_suffix: str | None = None,
+        *,
+        key: str | None = None,
+        icon: str | None = None,
     ) -> None:
         """Initialisiere die Basis-Entity."""
+        if dog_name and key and not name:
+            name = format_name(dog_name, key)
+        if key and not unique_suffix:
+            unique_suffix = key
+
         super().__init__(coordinator)
         self._attr_name = name
         self._dog_name = dog_name
@@ -28,6 +36,8 @@ class PawControlBaseEntity(CoordinatorEntity):
 
         if dog_name and unique_suffix:
             self._attr_unique_id = f"{DOMAIN}_{dog_name.lower()}_{unique_suffix}"
+        if icon or key:
+            self._attr_icon = icon or get_icon(key)
 
     @property
     def available(self) -> bool:

--- a/custom_components/pawcontrol/entities/binary_sensor.py
+++ b/custom_components/pawcontrol/entities/binary_sensor.py
@@ -2,7 +2,7 @@
 from homeassistant.components.binary_sensor import BinarySensorEntity
 
 from .base import PawControlBaseEntity
-from ..helpers.entity import as_bool, get_icon, format_name
+from ..helpers.entity import as_bool
 
 
 class PawControlBinarySensorEntity(PawControlBaseEntity, BinarySensorEntity):
@@ -19,12 +19,14 @@ class PawControlBinarySensorEntity(PawControlBaseEntity, BinarySensorEntity):
         icon: str | None = None,
         device_class=None,
     ) -> None:
-        if dog_name and key and not name:
-            name = format_name(dog_name, key)
-        if key and not unique_suffix:
-            unique_suffix = key
-        super().__init__(coordinator, name, dog_name, unique_suffix)
-        self._attr_icon = icon or (key and get_icon(key))
+        super().__init__(
+            coordinator,
+            name,
+            dog_name,
+            unique_suffix,
+            key=key,
+            icon=icon,
+        )
         if device_class:
             self._attr_device_class = device_class
 

--- a/custom_components/pawcontrol/entities/button.py
+++ b/custom_components/pawcontrol/entities/button.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from homeassistant.components.button import ButtonEntity
 
 from .base import PawControlBaseEntity
-from ..helpers.entity import format_name, get_icon
 from ..utils import safe_service_call
 
 
@@ -23,12 +22,14 @@ class PawControlButtonEntity(PawControlBaseEntity, ButtonEntity):
         key: str | None = None,
         icon: str | None = None,
     ) -> None:
-        if dog_name and key and not name:
-            name = format_name(dog_name, key)
-        if key and not unique_suffix:
-            unique_suffix = key
-        super().__init__(coordinator, name, dog_name, unique_suffix)
-        self._attr_icon = icon or (key and get_icon(key))
+        super().__init__(
+            coordinator,
+            name,
+            dog_name,
+            unique_suffix,
+            key=key,
+            icon=icon,
+        )
 
     async def _safe_service_call(self, domain: str, service: str, data: dict) -> bool:
         """Hilfsfunktion für sichere Serviceaufrufe."""

--- a/custom_components/pawcontrol/entities/datetime.py
+++ b/custom_components/pawcontrol/entities/datetime.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from homeassistant.components.datetime import DateTimeEntity
 
 from .base import PawControlBaseEntity
-from ..helpers.entity import parse_datetime, format_name, get_icon
+from ..helpers.entity import parse_datetime
 
 
 class PawControlDateTimeEntity(PawControlBaseEntity, DateTimeEntity):
@@ -23,13 +23,14 @@ class PawControlDateTimeEntity(PawControlBaseEntity, DateTimeEntity):
         has_date: bool = True,
         has_time: bool = True,
     ) -> None:
-        if dog_name and key and not name:
-            name = format_name(dog_name, key)
-        if key and not unique_suffix:
-            unique_suffix = key
-        super().__init__(coordinator, name, dog_name, unique_suffix)
-        if icon or key:
-            self._attr_icon = icon or get_icon(key)
+        super().__init__(
+            coordinator,
+            name,
+            dog_name,
+            unique_suffix,
+            key=key,
+            icon=icon,
+        )
         self._attr_has_date = has_date
         self._attr_has_time = has_time
 

--- a/custom_components/pawcontrol/entities/device_tracker.py
+++ b/custom_components/pawcontrol/entities/device_tracker.py
@@ -2,7 +2,6 @@
 from homeassistant.components.device_tracker import TrackerEntity
 
 from .base import PawControlBaseEntity
-from ..helpers.entity import format_name, get_icon
 from ..helpers.gps import format_gps_coords, is_valid_gps_coords
 
 
@@ -19,13 +18,14 @@ class PawControlDeviceTrackerEntity(PawControlBaseEntity, TrackerEntity):
         key: str | None = None,
         icon: str | None = None,
     ) -> None:
-        if dog_name and key and not name:
-            name = format_name(dog_name, key)
-        if key and not unique_suffix:
-            unique_suffix = key
-        super().__init__(coordinator, name, dog_name, unique_suffix)
-        if icon or key:
-            self._attr_icon = icon or get_icon(key)
+        super().__init__(
+            coordinator,
+            name,
+            dog_name,
+            unique_suffix,
+            key=key,
+            icon=icon,
+        )
 
     def _update_state(self) -> None:
         """Aktualisiere den internen GPS-Status."""

--- a/custom_components/pawcontrol/entities/number.py
+++ b/custom_components/pawcontrol/entities/number.py
@@ -2,7 +2,7 @@
 from homeassistant.components.number import NumberEntity
 
 from .base import PawControlBaseEntity
-from ..helpers.entity import clamp_value, get_icon, format_name
+from ..helpers.entity import clamp_value
 
 class PawControlNumberEntity(PawControlBaseEntity, NumberEntity):
     """Basisklasse für Number-Entities mit Validierung."""
@@ -24,14 +24,16 @@ class PawControlNumberEntity(PawControlBaseEntity, NumberEntity):
         mode: str | None = None,
         state_class: str | None = None,
     ) -> None:
-        if dog_name and key and not name:
-            name = format_name(dog_name, key)
-        if key and not unique_suffix:
-            unique_suffix = key
-        super().__init__(coordinator, name, dog_name, unique_suffix)
+        super().__init__(
+            coordinator,
+            name,
+            dog_name,
+            unique_suffix,
+            key=key,
+            icon=icon,
+        )
         self._attr_native_min_value = min_value
         self._attr_native_max_value = max_value
-        self._attr_icon = icon or (key and get_icon(key))
         if unit:
             self._attr_native_unit_of_measurement = unit
         if device_class:

--- a/custom_components/pawcontrol/entities/select.py
+++ b/custom_components/pawcontrol/entities/select.py
@@ -2,7 +2,7 @@
 from homeassistant.components.select import SelectEntity
 
 from .base import PawControlBaseEntity
-from ..helpers.entity import ensure_option, format_name, get_icon
+from ..helpers.entity import ensure_option
 
 class PawControlSelectEntity(PawControlBaseEntity, SelectEntity):
     """Basisklasse für Select-Entities mit Validierung."""
@@ -18,13 +18,14 @@ class PawControlSelectEntity(PawControlBaseEntity, SelectEntity):
         icon: str | None = None,
         options: list[str] | None = None,
     ) -> None:
-        if dog_name and key and not name:
-            name = format_name(dog_name, key)
-        if key and not unique_suffix:
-            unique_suffix = key
-        super().__init__(coordinator, name, dog_name, unique_suffix)
-        if icon or key:
-            self._attr_icon = icon or get_icon(key)
+        super().__init__(
+            coordinator,
+            name,
+            dog_name,
+            unique_suffix,
+            key=key,
+            icon=icon,
+        )
         self._attr_options = options or []
         if self._attr_options:
             self._state = self._attr_options[0]

--- a/custom_components/pawcontrol/entities/sensor.py
+++ b/custom_components/pawcontrol/entities/sensor.py
@@ -1,5 +1,4 @@
 from .base import PawControlBaseEntity
-from ..helpers.entity import get_icon, format_name
 
 class PawControlSensorEntity(PawControlBaseEntity):
     """Basisklasse für alle Sensoren mit gemeinsamer Initialisierung."""
@@ -16,12 +15,14 @@ class PawControlSensorEntity(PawControlBaseEntity):
         device_class=None,
         unit: str | None = None,
     ) -> None:
-        if dog_name and key and not name:
-            name = format_name(dog_name, key)
-        if key and not unique_suffix:
-            unique_suffix = key
-        super().__init__(coordinator, name, dog_name, unique_suffix)
-        self._attr_icon = icon or (key and get_icon(key))
+        super().__init__(
+            coordinator,
+            name,
+            dog_name,
+            unique_suffix,
+            key=key,
+            icon=icon,
+        )
         if device_class:
             self._attr_device_class = device_class
         if unit:

--- a/custom_components/pawcontrol/entities/switch.py
+++ b/custom_components/pawcontrol/entities/switch.py
@@ -2,7 +2,7 @@
 from homeassistant.components.switch import SwitchEntity
 
 from .base import PawControlBaseEntity
-from ..helpers.entity import as_bool, get_icon, format_name
+from ..helpers.entity import as_bool
 from ..utils import safe_service_call
 
 
@@ -19,12 +19,14 @@ class PawControlSwitchEntity(PawControlBaseEntity, SwitchEntity):
         key: str | None = None,
         icon: str | None = None,
     ) -> None:
-        if dog_name and key and not name:
-            name = format_name(dog_name, key)
-        if key and not unique_suffix:
-            unique_suffix = key
-        super().__init__(coordinator, name, dog_name, unique_suffix)
-        self._attr_icon = icon or (key and get_icon(key))
+        super().__init__(
+            coordinator,
+            name,
+            dog_name,
+            unique_suffix,
+            key=key,
+            icon=icon,
+        )
 
     def _update_state(self) -> None:
         """Hole und konvertiere den Status aus den Koordinatordaten."""

--- a/custom_components/pawcontrol/entities/text.py
+++ b/custom_components/pawcontrol/entities/text.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from homeassistant.components.text import TextEntity, TextMode
 
 from .base import PawControlBaseEntity
-from ..helpers.entity import clamp_string, format_name, get_icon
+from ..helpers.entity import clamp_string
 
 
 class PawControlTextEntity(PawControlBaseEntity, TextEntity):
@@ -23,13 +23,14 @@ class PawControlTextEntity(PawControlBaseEntity, TextEntity):
         max_length: int = 255,
         mode: TextMode = TextMode.TEXT,
     ) -> None:
-        if dog_name and key and not name:
-            name = format_name(dog_name, key)
-        if key and not unique_suffix:
-            unique_suffix = key
-        super().__init__(coordinator, name, dog_name, unique_suffix)
-        if icon or key:
-            self._attr_icon = icon or get_icon(key)
+        super().__init__(
+            coordinator,
+            name,
+            dog_name,
+            unique_suffix,
+            key=key,
+            icon=icon,
+        )
         self._attr_native_max = max_length
         self._attr_mode = mode
 


### PR DESCRIPTION
## Summary
- centralize common entity initialization logic in `PawControlBaseEntity`
- streamline binary sensor, sensor, and other entity classes to use the shared base

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890671d2a9083319ed56654d18cd122