### PR TITLE
refactor: centralize service call helper

### DIFF
--- a/custom_components/pawcontrol/entities/base.py
+++ b/custom_components/pawcontrol/entities/base.py
@@ -8,6 +8,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ..const import DOMAIN
 from ..helpers.entity import build_attributes, format_name, get_icon
+from ..utils import safe_service_call
 
 
 class PawControlBaseEntity(CoordinatorEntity):
@@ -76,3 +77,7 @@ class PawControlBaseEntity(CoordinatorEntity):
     def build_extra_attributes(self, **extra: Any) -> dict[str, Any]:
         """Hilfsfunktion für Unterklassen zur Attribut-Erstellung."""
         return build_attributes(self._dog_name, **extra)
+
+    async def _safe_service_call(self, domain: str, service: str, data: dict) -> bool:
+        """Hilfsfunktion für sichere Serviceaufrufe."""
+        return await safe_service_call(self.hass, domain, service, data)

--- a/custom_components/pawcontrol/entities/button.py
+++ b/custom_components/pawcontrol/entities/button.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from homeassistant.components.button import ButtonEntity
 
 from .base import PawControlBaseEntity
-from ..utils import safe_service_call
 
 
 class PawControlButtonEntity(PawControlBaseEntity, ButtonEntity):
@@ -30,10 +29,6 @@ class PawControlButtonEntity(PawControlBaseEntity, ButtonEntity):
             key=key,
             icon=icon,
         )
-
-    async def _safe_service_call(self, domain: str, service: str, data: dict) -> bool:
-        """Hilfsfunktion für sichere Serviceaufrufe."""
-        return await safe_service_call(self.hass, domain, service, data)
 
     async def async_press(self) -> None:  # pragma: no cover - muss in Unterklassen implementiert werden
         """Button-Logik in Unterklassen bereitstellen."""

--- a/custom_components/pawcontrol/entities/switch.py
+++ b/custom_components/pawcontrol/entities/switch.py
@@ -3,7 +3,6 @@ from homeassistant.components.switch import SwitchEntity
 
 from .base import PawControlBaseEntity
 from ..helpers.entity import as_bool
-from ..utils import safe_service_call
 
 
 class PawControlSwitchEntity(PawControlBaseEntity, SwitchEntity):
@@ -43,7 +42,3 @@ class PawControlSwitchEntity(PawControlBaseEntity, SwitchEntity):
     async def async_turn_off(self, **kwargs):
         # Geräte ausschalten
         pass
-
-    async def _safe_service_call(self, domain: str, service: str, data: dict) -> bool:
-        """Hilfsfunktion für sichere Serviceaufrufe."""
-        return await safe_service_call(self.hass, domain, service, data)


### PR DESCRIPTION
## Summary
- centralize safe service call helper in base entity
- drop duplicated helper methods from button and switch entities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689069ab84288331b44beda549abed65