### PR TITLE
refactor: enhance setup and initialization

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -7,17 +7,36 @@ from homeassistant.core import HomeAssistant
 
 from .installation_manager import InstallationManager
 
+# Integration domain
+DOMAIN = "pawcontrol"
 
 # Single instance of the manager used by Home Assistant during setup
 manager = InstallationManager()
 
 
+def _get_domain_data(hass: HomeAssistant) -> dict:
+    """Return the storage dictionary for this domain on the hass object."""
+    if not hasattr(hass, "data"):
+        hass.data = {}
+    return hass.data.setdefault(DOMAIN, {})
+
+
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
+    """Set up the Paw Control integration (YAML not supported)."""
+    _get_domain_data(hass)
+    return True
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Paw Control from a config entry."""
+    _get_domain_data(hass)[entry.entry_id] = manager
     return await manager.setup_entry(hass, entry)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a Paw Control config entry."""
-    return await manager.unload_entry(hass, entry)
+    unload_ok = await manager.unload_entry(hass, entry)
+    if unload_ok:
+        _get_domain_data(hass).pop(entry.entry_id, None)
+    return unload_ok
 

--- a/custom_components/pawcontrol/activity_logger.py
+++ b/custom_components/pawcontrol/activity_logger.py
@@ -51,14 +51,14 @@ async def async_log_activity(
         
         # Update last activity text
         readable_activities = {
-            "walk": "Gassi",
-            "feeding": "Fütterung", 
-            "outside": "Draußen",
-            "poop": "Geschäft",
-            "play": "Spielen",
+            "walk": "Walk",
+            "feeding": "Feeding",
+            "outside": "Outside",
+            "poop": "Potty",
+            "play": "Play",
             "training": "Training",
-            "medication": "Medikament",
-            "health_check": "Gesundheitscheck"
+            "medication": "Medication",
+            "health_check": "Health check",
         }
         
         activity_label = readable_activities.get(activity_type, activity_type.title())
@@ -154,11 +154,11 @@ async def async_log_health_event(
     """Log a health-related event."""
     
     health_events = {
-        "medication": "Medikament gegeben",
-        "vet_visit": "Tierarztbesuch",
-        "health_check": "Gesundheitscheck",
-        "vaccination": "Impfung",
-        "weight_check": "Gewichtskontrolle"
+        "medication": "Medication given",
+        "vet_visit": "Vet visit",
+        "health_check": "Health check",
+        "vaccination": "Vaccination",
+        "weight_check": "Weight check",
     }
     
     event_label = health_events.get(event_type, event_type)
@@ -175,33 +175,33 @@ async def async_get_daily_summary(hass: HomeAssistant, dog_name: str) -> str:
         activities = {}
         
         activity_counters = [
-            ("feeding_morning", "Frühstück"),
-            ("feeding_lunch", "Mittag"),
-            ("feeding_evening", "Abend"),
+            ("feeding_morning", "Breakfast"),
+            ("feeding_lunch", "Lunch"),
+            ("feeding_evening", "Dinner"),
             ("feeding_snack", "Snacks"),
-            ("outside", "Draußen"),
-            ("walk", "Gassi"),
-            ("play", "Spielen"),
+            ("outside", "Outside"),
+            ("walk", "Walk"),
+            ("play", "Play"),
             ("training", "Training"),
-            ("poop", "Geschäfte")
+            ("poop", "Potty"),
         ]
-        
+
         for counter_suffix, label in activity_counters:
             counter_entity = f"counter.{dog_id}_{counter_suffix}_count"
             state = hass.states.get(counter_entity)
             if state and state.state != "0":
                 activities[label] = state.state
-        
+
         if not activities:
-            return f"{dog_name.title()}: Noch keine Aktivitäten heute"
-        
+            return f"{dog_name.title()}: No activities recorded today"
+
         # Format summary
         summary_parts = []
         for activity, count in activities.items():
             summary_parts.append(f"{activity}: {count}x")
-        
+
         return f"{dog_name.title()}: " + ", ".join(summary_parts)
         
     except Exception as e:
         _LOGGER.error("Failed to generate daily summary for %s: %s", dog_name, e)
-        return f"{dog_name.title()}: Zusammenfassung nicht verfügbar"
+        return f"{dog_name.title()}: Summary not available"

--- a/custom_components/pawcontrol/entities/__init__.py
+++ b/custom_components/pawcontrol/entities/__init__.py
@@ -1,4 +1,4 @@
-"""Hilfspaket mit Basis-Entity-Klassen für Paw Control."""
+"""Helper package with base entity classes for Paw Control."""
 
 from .base import PawControlBaseEntity
 from .binary_sensor import PawControlBinarySensorEntity

--- a/custom_components/pawcontrol/helpers/__init__.py
+++ b/custom_components/pawcontrol/helpers/__init__.py
@@ -1,2 +1,6 @@
-"""Helper-Module für Paw Control Entities."""
+"""Helper modules for Paw Control entities."""
+
+from . import entity, gps
+
+__all__ = ["entity", "gps"]
 

--- a/custom_components/pawcontrol/setup_helpers.py
+++ b/custom_components/pawcontrol/setup_helpers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 from homeassistant.core import HomeAssistant
 from homeassistant.components.input_datetime import (
     DOMAIN as INPUT_DATETIME_DOMAIN,
@@ -23,44 +25,44 @@ async def async_create_helpers_for_dog(hass: HomeAssistant, dog_id: str) -> None
     async def _svc(domain: str, service: str, data: dict) -> None:
         await safe_service_call(hass, domain, service, data)
 
-    # Timestamp Helper (e.g. last walk)
-    await _svc(
-        INPUT_DATETIME_DOMAIN,
-        "set_datetime",
-        {
-            "entity_id": f"input_datetime.last_walk_{dog_id}",
-            "timestamp": now().timestamp(),
-        },
-    )
-
-    # Counters for daily events
-    for counter in ["feeding", "walk", "potty"]:
-        await _svc(
-            COUNTER_DOMAIN,
-            "configure",
+    tasks = [
+        _svc(
+            INPUT_DATETIME_DOMAIN,
+            "set_datetime",
             {
-                "entity_id": f"counter.{counter}_{dog_id}",
-                "initial": 0,
-                "minimum": 0,
-                "maximum": 20,
-                "step": 1,
-                "restore": True,
+                "entity_id": f"input_datetime.last_walk_{dog_id}",
+                "timestamp": now().timestamp(),
             },
+        ),
+        _svc(
+            INPUT_BOOLEAN_DOMAIN,
+            "turn_off",
+            {"entity_id": f"input_boolean.visitor_mode_{dog_id}"},
+        ),
+        _svc(
+            "input_text",
+            "set_value",
+            {
+                "entity_id": f"input_text.last_activity_{dog_id}",
+                "value": "No activity yet",
+            },
+        ),
+    ]
+
+    for counter in ["feeding", "walk", "potty"]:
+        tasks.append(
+            _svc(
+                COUNTER_DOMAIN,
+                "configure",
+                {
+                    "entity_id": f"counter.{counter}_{dog_id}",
+                    "initial": 0,
+                    "minimum": 0,
+                    "maximum": 20,
+                    "step": 1,
+                    "restore": True,
+                },
+            )
         )
 
-    # Boolean: visitor mode for this dog
-    await _svc(
-        INPUT_BOOLEAN_DOMAIN,
-        "turn_off",
-        {"entity_id": f"input_boolean.visitor_mode_{dog_id}"},
-    )
-
-    # Last activity text helper
-    await _svc(
-        "input_text",
-        "set_value",
-        {
-            "entity_id": f"input_text.last_activity_{dog_id}",
-            "value": "Noch keine Aktivität",
-        },
-    )
+    await asyncio.gather(*tasks)


### PR DESCRIPTION
## Summary
- streamline integration setup and data storage
- parallelize helper creation and use English defaults
- translate remaining activity log strings and expose helper modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68906ffebe088331abb0918a4bf29566