### PR TITLE
chore: streamline project configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/release.yml
+++ b/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ github.ref_name }}
     
     permissions:
       contents: write
@@ -31,7 +33,7 @@ jobs:
           
           # Create ZIP archive
           cd release_tmp
-          zip -r ../paw_control-${GITHUB_REF#refs/tags/}.zip ./*
+          zip -r ../paw_control-${VERSION}.zip ./*
           cd ..
           
           # Cleanup
@@ -44,7 +46,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            paw_control-*.zip
+            paw_control-${{ env.VERSION }}.zip
           draft: false
           prerelease: false
           generate_release_notes: true

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,6 @@
 # Development dependencies for Paw Control
-homeassistant>=2024.1.0
-voluptuous>=0.13.1
-aiohttp>=3.8.0
+# Include runtime requirements
+-r requirements.txt
 
 # Development tools
 black>=23.0.0
@@ -13,6 +12,7 @@ pytest>=7.0.0
 pytest-homeassistant-custom-component>=0.13.0
 pytest-cov>=4.0.0
 pytest-asyncio>=0.21.0
+ruff>=0.1.0
 
 # Type stubs
 types-requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ url = https://github.com/BigDaddy1990/paw_control
 author = BigDaddy1990
 author_email = bigdaddy1990@example.com
 license = MIT
-license_file = LICENSE
+license_files = LICENSE
 classifiers =
     Development Status :: 5 - Production/Stable
     Intended Audience :: End Users/Desktop


### PR DESCRIPTION
## Summary
- add project-wide `.editorconfig`
- reference runtime requirements in development requirements and add ruff
- clarify release workflow versioning
- use `license_files` in `setup.cfg`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689072208b708331b10807e0065fea8c