### PR TITLE
Handle invalid coordinate strings consistently

### DIFF
--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -304,22 +304,30 @@ def generate_entity_id(dog_name: str, entity_type: str, suffix: str) -> str:
 
 
 def parse_coordinates_string(coord_string: str) -> Tuple[float, float]:
-    """Parse coordinates from string format 'latitude,longitude'."""
+    """Parse coordinates from string format 'latitude,longitude'.
+
+    Any parsing issues should raise :class:`InvalidCoordinates` rather than
+    bubbling up builtin exceptions like ``AttributeError`` or ``TypeError``.
+    This ensures callers can consistently handle invalid input types or
+    malformed strings.
+    """
     try:
         parts = coord_string.split(',')
         if len(parts) != 2:
             raise ValueError("Invalid coordinate format")
-        
+
         lat = float(parts[0].strip())
         lon = float(parts[1].strip())
-        
+
         if not validate_coordinates(lat, lon):
             raise ValueError("Invalid coordinate values")
-        
+
         return lat, lon
-        
-    except (ValueError, IndexError) as e:
-        raise InvalidCoordinates(f"Could not parse coordinates '{coord_string}': {e}")
+
+    except (ValueError, IndexError, TypeError, AttributeError) as e:
+        raise InvalidCoordinates(
+            f"Could not parse coordinates '{coord_string}': {e}"
+        ) from e
 
 
 def format_coordinates(latitude: float, longitude: float, precision: int = 6) -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,7 +21,9 @@ from custom_components.pawcontrol.utils import (
     time_since_last_activity,
     validate_dog_name,
     validate_weight,
+    parse_coordinates_string,
 )
+from custom_components.pawcontrol.exceptions import InvalidCoordinates
 
 
 def test_calculate_dog_calories_positive():
@@ -150,3 +152,11 @@ def test_validate_dog_name_enforces_rules():
     assert not validate_dog_name("1Buddy")
     assert not validate_dog_name("Bad!")
     assert not validate_dog_name("a" * 31)
+
+
+def test_parse_coordinates_string_invalid_inputs():
+    """parse_coordinates_string should raise InvalidCoordinates for bad input."""
+    with pytest.raises(InvalidCoordinates):
+        parse_coordinates_string("10")  # missing lon
+    with pytest.raises(InvalidCoordinates):
+        parse_coordinates_string(None)


### PR DESCRIPTION
## Summary
- ensure parse_coordinates_string raises InvalidCoordinates for malformed input
- add tests covering invalid coordinate strings

## Testing
- `pytest`
- `pre-commit run --all-files` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892fefcfb848331bec8a5f38108b68b