### PR TITLE
Use defined feeding type options

### DIFF
--- a/custom_components/pawcontrol/config_flow.py
+++ b/custom_components/pawcontrol/config_flow.py
@@ -22,6 +22,7 @@ from .const import (
     CONF_DOG_NAME,
     CONF_DOG_WEIGHT,
     CONF_FEEDING_TIMES,
+    FEEDING_TYPES,
     CONF_VET_CONTACT,
     CONF_WALK_DURATION,
     DEFAULT_FEEDING_TIMES,
@@ -53,7 +54,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             ),
             vol.Optional(
                 CONF_FEEDING_TIMES, default=list(DEFAULT_FEEDING_TIMES)
-            ): cv.multi_select(DEFAULT_FEEDING_TIMES),
+            ): cv.multi_select(FEEDING_TYPES),
             vol.Optional(CONF_WALK_DURATION, default=DEFAULT_WALK_DURATION): vol.All(
                 vol.Coerce(int), vol.Range(min=0)
             ),

--- a/tests/test_config_flow_defaults.py
+++ b/tests/test_config_flow_defaults.py
@@ -17,8 +17,8 @@ from custom_components.pawcontrol.const import CONF_DOG_NAME, CONF_FEEDING_TIMES
     "defaults",
     [
         [],
-        ["08:00"],
-        ["08:00", "20:00"],
+        ["morning"],
+        ["morning", "evening"],
     ],
 )
 def test_feeding_times_default_is_copied(defaults, monkeypatch):
@@ -37,3 +37,20 @@ def test_feeding_times_default_is_copied(defaults, monkeypatch):
     data[CONF_FEEDING_TIMES].append("extra")
     assert config_flow.DEFAULT_FEEDING_TIMES == defaults
     assert const.DEFAULT_FEEDING_TIMES == defaults
+
+
+def test_feeding_times_options(monkeypatch):
+    """Ensure feeding time options come from FEEDING_TYPES."""
+    flow = config_flow.ConfigFlow()
+    flow.hass = SimpleNamespace()
+
+    result = asyncio.run(flow.async_step_user())
+    schema = result["data_schema"].schema
+
+    for key, validator in schema.items():
+        if getattr(key, "schema", None) == CONF_FEEDING_TIMES:
+            assert isinstance(validator, config_flow.cv.multi_select)
+            assert validator.options == const.FEEDING_TYPES
+            break
+    else:  # pragma: no cover - defensive, should not happen
+        pytest.fail("feeding times not in schema")


### PR DESCRIPTION
## Summary
- pull available feeding time choices from `FEEDING_TYPES`
- test that config flow exposes feeding type options

## Testing
- `pytest`
- Attempted `pre-commit run --files custom_components/pawcontrol/config_flow.py tests/test_config_flow_defaults.py` *(fails: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_6893052b73ec8331817273a8d487450d