### PR TITLE
Refactor setup and initialization flow

### DIFF
--- a/custom_components/pawcontrol/installation_manager.py
+++ b/custom_components/pawcontrol/installation_manager.py
@@ -23,36 +23,33 @@ class InstallationManager:
 
     async def setup_entry(self, hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Set up the integration and selected modules."""
-        # Merge config entry data and options, with options taking precedence
         opts = merge_entry_options(entry)
 
-        # Some parts of the integration – especially helper creation – expect a
-        # dog name to be present.  The title of the entry is the dog name in the
-        # config flow, so fall back to that if the name is missing from the
-        # stored data. This allows setup to proceed without crashing when the
-        # data is incomplete while still making the name available to modules.
         dog_present = CONF_DOG_NAME in opts
         dog_name = opts.setdefault(CONF_DOG_NAME, entry.title)
 
-        # Ensure helper entities for enabled modules then set them up
-        await async_ensure_helpers(hass, opts)
-        await async_setup_modules(hass, entry, opts)
+        try:
+            await async_ensure_helpers(hass, opts)
+            await async_setup_modules(hass, entry, opts)
+        except Exception:  # pragma: no cover - defensive programming
+            _LOGGER.exception("Error setting up modules for entry %s", entry.entry_id)
+            return False
 
-        # Create dashboard if requested. Only honour the request when the dog
-        # name was explicitly provided in the stored data/options.  This avoids
-        # creating dashboards accidentally if we only inferred the name from the
-        # entry title above.
         if opts.get(CONF_CREATE_DASHBOARD, False):
             if dog_present and dog_name:
                 await dashboard.create_dashboard(hass, dog_name)
             else:
                 _LOGGER.warning(
-                    "Dashboard creation requested but no dog name provided"
+                    "Dashboard creation requested but no dog name provided",
                 )
 
         return True
 
     async def unload_entry(self, hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Unload the integration and clean up modules."""
-        await async_unload_modules(hass, entry)
+        try:
+            await async_unload_modules(hass, entry)
+        except Exception:  # pragma: no cover - defensive programming
+            _LOGGER.exception("Error unloading modules for entry %s", entry.entry_id)
+            return False
         return True

--- a/custom_components/pawcontrol/setup_helpers.py
+++ b/custom_components/pawcontrol/setup_helpers.py
@@ -25,8 +25,8 @@ async def async_create_helpers_for_dog(hass: HomeAssistant, dog_id: str) -> None
     async def _svc(domain: str, service: str, data: dict) -> None:
         await safe_service_call(hass, domain, service, data)
 
-    tasks = [
-        _svc(
+    helper_calls: list[tuple[str, str, dict]] = [
+        (
             INPUT_DATETIME_DOMAIN,
             "set_datetime",
             {
@@ -34,12 +34,12 @@ async def async_create_helpers_for_dog(hass: HomeAssistant, dog_id: str) -> None
                 "timestamp": now().timestamp(),
             },
         ),
-        _svc(
+        (
             INPUT_BOOLEAN_DOMAIN,
             "turn_off",
             {"entity_id": f"input_boolean.visitor_mode_{dog_id}"},
         ),
-        _svc(
+        (
             "input_text",
             "set_value",
             {
@@ -49,20 +49,22 @@ async def async_create_helpers_for_dog(hass: HomeAssistant, dog_id: str) -> None
         ),
     ]
 
+    counter_cfg = {
+        "initial": 0,
+        "minimum": 0,
+        "maximum": 20,
+        "step": 1,
+        "restore": True,
+    }
     for counter in ["feeding", "walk", "potty"]:
-        tasks.append(
-            _svc(
+        helper_calls.append(
+            (
                 COUNTER_DOMAIN,
                 "configure",
-                {
-                    "entity_id": f"counter.{counter}_{dog_id}",
-                    "initial": 0,
-                    "minimum": 0,
-                    "maximum": 20,
-                    "step": 1,
-                    "restore": True,
-                },
+                {"entity_id": f"counter.{counter}_{dog_id}", **counter_cfg},
             )
         )
 
-    await asyncio.gather(*tasks)
+    await asyncio.gather(
+        *(_svc(domain, service, data) for domain, service, data in helper_calls)
+    )


### PR DESCRIPTION
## Summary
- refine domain data handling and per-entry manager instantiation
- add defensive error handling for module setup and unload
- streamline helper creation and entity repair utilities

## Testing
- `ruff check custom_components/pawcontrol/__init__.py custom_components/pawcontrol/setup_helpers.py custom_components/pawcontrol/setup_verifier.py custom_components/pawcontrol/installation_manager.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893b3547ec48331b245709fc8ac4a95