### PR TITLE
Refactor installation validator and tidy tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+"""Test package for Paw Control."""
+

--- a/tests/test_entity_helpers.py
+++ b/tests/test_entity_helpers.py
@@ -1,10 +1,3 @@
-import os
-import sys
-
-import pytest
-
-sys.path.insert(0, os.path.abspath("."))
-
 from custom_components.pawcontrol.helpers.entity import (
     as_bool,
     clamp_value,
@@ -26,7 +19,7 @@ def test_ensure_option():
 
 
 def test_as_bool():
-    assert as_bool(True) is True
+    assert as_bool(value=True) is True
     assert as_bool("on") is True
     assert as_bool("off") is False
     assert as_bool(0) is False


### PR DESCRIPTION
## Summary
- modernize installation validation script with logging, pathlib helpers and safer error handling
- streamline entity helper tests and mark test directory as package

## Testing
- `ruff check validate_installation.py tests/test_entity_helpers.py tests/__init__.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893bb6bbaec833198c53c06f04b1743