### PR TITLE
feat: improve setup helpers and reload support

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -43,3 +43,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         return False
     return await manager.unload_entry(hass, entry)
 
+
+async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Handle reloading a config entry by unloading and setting it up again."""
+    if not await async_unload_entry(hass, entry):
+        return False
+    return await async_setup_entry(hass, entry)
+

--- a/custom_components/pawcontrol/setup_helpers.py
+++ b/custom_components/pawcontrol/setup_helpers.py
@@ -5,16 +5,13 @@ from __future__ import annotations
 import asyncio
 import logging
 
+from dataclasses import dataclass
+from typing import Any
+
 from homeassistant.core import HomeAssistant
-from homeassistant.components.input_datetime import (
-    DOMAIN as INPUT_DATETIME_DOMAIN,
-)
-from homeassistant.components.input_boolean import (
-    DOMAIN as INPUT_BOOLEAN_DOMAIN,
-)
-from homeassistant.components.counter import (
-    DOMAIN as COUNTER_DOMAIN,
-)
+from homeassistant.components.input_datetime import DOMAIN as INPUT_DATETIME_DOMAIN
+from homeassistant.components.input_boolean import DOMAIN as INPUT_BOOLEAN_DOMAIN
+from homeassistant.components.counter import DOMAIN as COUNTER_DOMAIN
 from homeassistant.util.dt import now
 
 from .utils import safe_service_call
@@ -22,19 +19,40 @@ from .utils import safe_service_call
 _LOGGER = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True)
+class HelperCall:
+    """Container describing a helper service call."""
+
+    domain: str
+    service: str
+    data: dict[str, Any]
+
+
+COUNTER_HELPERS = ("feeding", "walk", "potty")
+COUNTER_CFG: dict[str, Any] = {
+    "initial": 0,
+    "minimum": 0,
+    "maximum": 20,
+    "step": 1,
+    "restore": True,
+}
+
+
 async def async_create_helpers_for_dog(hass: HomeAssistant, dog_id: str) -> None:
     """Create helper entities required for core features."""
 
-    async def _svc(domain: str, service: str, data: dict) -> None:
+    async def _svc(call: HelperCall) -> None:
         try:
-            await safe_service_call(hass, domain, service, data)
+            await safe_service_call(hass, call.domain, call.service, call.data)
         except Exception:  # pragma: no cover - defensive programming
             _LOGGER.exception(
-                "Error creating helper %s for dog %s", data.get("entity_id", "?"), dog_id
+                "Error creating helper %s for dog %s",
+                call.data.get("entity_id", "?"),
+                dog_id,
             )
 
-    helper_calls: list[tuple[str, str, dict]] = [
-        (
+    helper_calls: list[HelperCall] = [
+        HelperCall(
             INPUT_DATETIME_DOMAIN,
             "set_datetime",
             {
@@ -42,12 +60,12 @@ async def async_create_helpers_for_dog(hass: HomeAssistant, dog_id: str) -> None
                 "timestamp": now().timestamp(),
             },
         ),
-        (
+        HelperCall(
             INPUT_BOOLEAN_DOMAIN,
             "turn_off",
             {"entity_id": f"input_boolean.visitor_mode_{dog_id}"},
         ),
-        (
+        HelperCall(
             "input_text",
             "set_value",
             {
@@ -57,25 +75,16 @@ async def async_create_helpers_for_dog(hass: HomeAssistant, dog_id: str) -> None
         ),
     ]
 
-    counter_cfg = {
-        "initial": 0,
-        "minimum": 0,
-        "maximum": 20,
-        "step": 1,
-        "restore": True,
-    }
-    for counter in ["feeding", "walk", "potty"]:
+    for counter in COUNTER_HELPERS:
         helper_calls.append(
-            (
+            HelperCall(
                 COUNTER_DOMAIN,
                 "configure",
-                {"entity_id": f"counter.{counter}_{dog_id}", **counter_cfg},
+                {"entity_id": f"counter.{counter}_{dog_id}", **COUNTER_CFG},
             )
         )
 
-    await asyncio.gather(
-        *(_svc(domain, service, data) for domain, service, data in helper_calls)
-    )
+    await asyncio.gather(*(_svc(call) for call in helper_calls))
 
 
 __all__ = ["async_create_helpers_for_dog"]

--- a/tests/test_reload_entry.py
+++ b/tests/test_reload_entry.py
@@ -1,0 +1,56 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from custom_components.pawcontrol import (
+    async_reload_entry,
+    async_setup_entry,
+    async_unload_entry,
+)
+
+
+def test_reload_entry_calls_setup_and_unload():
+    """Reloading a config entry unloads and sets it up again."""
+
+    async def run_test() -> None:
+        hass = object()
+        entry = object()
+        with (
+            patch(
+                "custom_components.pawcontrol.async_unload_entry",
+                AsyncMock(return_value=True),
+            ) as unload,
+            patch(
+                "custom_components.pawcontrol.async_setup_entry",
+                AsyncMock(return_value=True),
+            ) as setup,
+        ):
+            result = await async_reload_entry(hass, entry)
+        assert result is True
+        unload.assert_awaited_once_with(hass, entry)
+        setup.assert_awaited_once_with(hass, entry)
+
+    asyncio.run(run_test())
+
+
+def test_reload_entry_aborts_when_unload_fails():
+    """Reload fails if unloading fails."""
+
+    async def run_test() -> None:
+        hass = object()
+        entry = object()
+        with (
+            patch(
+                "custom_components.pawcontrol.async_unload_entry",
+                AsyncMock(return_value=False),
+            ) as unload,
+            patch(
+                "custom_components.pawcontrol.async_setup_entry",
+                AsyncMock(return_value=True),
+            ) as setup,
+        ):
+            result = await async_reload_entry(hass, entry)
+        assert result is False
+        unload.assert_awaited_once_with(hass, entry)
+        setup.assert_not_awaited()
+
+    asyncio.run(run_test())

--- a/tests/test_setup_helpers.py
+++ b/tests/test_setup_helpers.py
@@ -1,0 +1,30 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from custom_components.pawcontrol import setup_helpers
+
+
+def test_async_create_helpers_for_dog_invokes_expected_services():
+    """Ensure helper creation issues the correct service calls."""
+
+    async def run_test() -> None:
+        hass = object()
+        with patch(
+            "custom_components.pawcontrol.setup_helpers.safe_service_call",
+            AsyncMock(),
+        ) as mock_call:
+            await setup_helpers.async_create_helpers_for_dog(hass, "rex")
+        # Three base helpers + three counter helpers
+        assert mock_call.await_count == 6
+        domains = [call.args[1] for call in mock_call.await_args_list]
+        services = [call.args[2] for call in mock_call.await_args_list]
+        assert domains.count("input_datetime") == 1
+        assert domains.count("input_boolean") == 1
+        assert domains.count("input_text") == 1
+        assert domains.count("counter") == 3
+        assert "set_datetime" in services
+        assert "turn_off" in services
+        assert "set_value" in services
+        assert services.count("configure") == 3
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- refactor helper creation with structured service calls
- add config entry reload support
- cover reload logic and helper creation in tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893bd23d3d48331a0e3b0b8c17f4880