### PR TITLE
Register notification service during setup

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -7,10 +7,9 @@ from typing import Any
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
+from .actionable_push import setup_actionable_notifications
+from .const import DOMAIN
 from .installation_manager import InstallationManager
-
-# Integration domain
-DOMAIN = "pawcontrol"
 
 
 def _get_domain_data(hass: HomeAssistant) -> dict[str, Any]:
@@ -24,6 +23,7 @@ def _get_domain_data(hass: HomeAssistant) -> dict[str, Any]:
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up the Paw Control integration (YAML not supported)."""
     _get_domain_data(hass)
+    setup_actionable_notifications(hass)
     return True
 
 
@@ -42,4 +42,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if manager is None:
         return False
     return await manager.unload_entry(hass, entry)
-

--- a/custom_components/pawcontrol/actionable_push.py
+++ b/custom_components/pawcontrol/actionable_push.py
@@ -1,10 +1,16 @@
-from homeassistant.core import HomeAssistant, ServiceCall
+"""Actionable push notification helpers for Paw Control."""
+
+from __future__ import annotations
+
 import logging
 
-_LOGGER = logging.getLogger(__name__)
-DOMAIN = "pawcontrol"
+from homeassistant.core import HomeAssistant, ServiceCall
 
+from .const import DOMAIN
 from .utils import register_services
+
+_LOGGER = logging.getLogger(__name__)
+
 
 async def handle_send_notification(call: ServiceCall):
     hass: HomeAssistant = call.hass
@@ -32,28 +38,24 @@ async def handle_send_notification(call: ServiceCall):
         _LOGGER.warning("Keine gültigen Notify-Ziele gefunden")
         return
 
-    actions = call.data.get("actions", [
-        {"action": "yes", "title": "Ja"},
-        {"action": "no", "title": "Nein"}
-    ])
+    actions = call.data.get(
+        "actions", [{"action": "yes", "title": "Ja"}, {"action": "no", "title": "Nein"}]
+    )
     data = {
         "actions": actions,
         "tag": f"{dog_name}_frage",
         "group": f"paw_control_{dog_name}",
-        "clickAction": "/lovelace/pawcontrol"
+        "clickAction": "/lovelace/pawcontrol",
     }
 
     for notify_target in notify_targets:
         await hass.services.async_call(
             "notify",
             notify_target,
-            {
-                "title": title,
-                "message": message,
-                "data": data
-            },
+            {"title": title, "message": message, "data": data},
             blocking=False,
         )
+
 
 def setup_actionable_notifications(hass: HomeAssistant):
     register_services(hass, DOMAIN, {"send_notification": handle_send_notification})

--- a/tests/test_init_services.py
+++ b/tests/test_init_services.py
@@ -1,0 +1,35 @@
+import asyncio
+import os
+import sys
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.abspath("."))
+
+from custom_components.pawcontrol import async_setup
+from custom_components.pawcontrol.const import DOMAIN
+
+
+def _hass():
+    services: dict[str, dict[str, object]] = {}
+
+    def async_register(domain, service, handler):
+        services.setdefault(domain, {})[service] = handler
+
+    def has_service(domain, service):
+        return service in services.get(domain, {})
+
+    return SimpleNamespace(
+        data={},
+        services=SimpleNamespace(
+            async_register=async_register, has_service=has_service
+        ),
+    )
+
+
+def test_async_setup_registers_actionable_service():
+    async def run_test():
+        hass = _hass()
+        assert await async_setup(hass, {})
+        assert hass.services.has_service(DOMAIN, "send_notification")
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- avoid repeating DOMAIN constant in module-level files
- register actionable notification service when integration is set up
- cover service registration with a unit test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893bd23d3d48331a0e3b0b8c17f4880