### PR TITLE
feat: add helper cleanup and reload support

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import logging
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
@@ -11,6 +13,8 @@ from .installation_manager import InstallationManager
 
 # Integration domain
 DOMAIN = "pawcontrol"
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def _get_domain_data(hass: HomeAssistant) -> dict[str, Any]:
@@ -22,8 +26,12 @@ def _get_domain_data(hass: HomeAssistant) -> dict[str, Any]:
 
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
-    """Set up the Paw Control integration (YAML not supported)."""
+    """Set up the Paw Control integration (YAML configuration not supported)."""
     _get_domain_data(hass)
+
+    if DOMAIN in config:
+        _LOGGER.warning("Configuration via YAML is not supported")
+
     return True
 
 
@@ -42,4 +50,19 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if manager is None:
         return False
     return await manager.unload_entry(hass, entry)
+
+
+async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Handle reload of a config entry."""
+    await async_unload_entry(hass, entry)
+    return await async_setup_entry(hass, entry)
+
+
+__all__ = [
+    "DOMAIN",
+    "async_setup",
+    "async_setup_entry",
+    "async_unload_entry",
+    "async_reload_entry",
+]
 

--- a/custom_components/pawcontrol/installation_manager.py
+++ b/custom_components/pawcontrol/installation_manager.py
@@ -13,6 +13,7 @@ from .module_registry import (
     async_setup_modules,
     async_unload_modules,
 )
+from .setup_helpers import async_remove_helpers_for_dog
 from .utils import merge_entry_options
 
 _LOGGER = logging.getLogger(__name__)
@@ -43,6 +44,8 @@ class InstallationManager:
         """Unload the integration and clean up modules."""
         try:
             await async_unload_modules(hass, entry)
+            dog_id = entry.data.get(CONF_DOG_NAME, entry.title)
+            await async_remove_helpers_for_dog(hass, dog_id)
         except Exception:  # pragma: no cover - defensive programming
             _LOGGER.exception("Error unloading modules for entry %s", entry.entry_id)
             return False

--- a/custom_components/pawcontrol/setup_helpers.py
+++ b/custom_components/pawcontrol/setup_helpers.py
@@ -78,4 +78,47 @@ async def async_create_helpers_for_dog(hass: HomeAssistant, dog_id: str) -> None
     )
 
 
-__all__ = ["async_create_helpers_for_dog"]
+async def async_remove_helpers_for_dog(hass: HomeAssistant, dog_id: str) -> None:
+    """Remove helper entities created for core features."""
+
+    async def _svc(domain: str, service: str, data: dict) -> None:
+        try:
+            await safe_service_call(hass, domain, service, data)
+        except Exception:  # pragma: no cover - defensive programming
+            _LOGGER.exception(
+                "Error removing helper %s for dog %s", data.get("entity_id", "?"), dog_id
+            )
+
+    helper_calls: list[tuple[str, str, dict]] = [
+        (
+            INPUT_DATETIME_DOMAIN,
+            "remove",
+            {"entity_id": f"input_datetime.last_walk_{dog_id}"},
+        ),
+        (
+            INPUT_BOOLEAN_DOMAIN,
+            "remove",
+            {"entity_id": f"input_boolean.visitor_mode_{dog_id}"},
+        ),
+        (
+            "input_text",
+            "remove",
+            {"entity_id": f"input_text.last_activity_{dog_id}"},
+        ),
+    ]
+
+    for counter in ["feeding", "walk", "potty"]:
+        helper_calls.append(
+            (
+                COUNTER_DOMAIN,
+                "remove",
+                {"entity_id": f"counter.{counter}_{dog_id}"},
+            )
+        )
+
+    await asyncio.gather(
+        *(_svc(domain, service, data) for domain, service, data in helper_calls)
+    )
+
+
+__all__ = ["async_create_helpers_for_dog", "async_remove_helpers_for_dog"]

--- a/tests/test_installation_manager.py
+++ b/tests/test_installation_manager.py
@@ -123,14 +123,22 @@ def test_unload_entry_calls_module_unload():
         )
 
         unload_mock = AsyncMock()
+        remove_mock = AsyncMock()
 
-        with patch(
-            "custom_components.pawcontrol.installation_manager.async_unload_modules",
-            unload_mock,
+        with (
+            patch(
+                "custom_components.pawcontrol.installation_manager.async_unload_modules",
+                unload_mock,
+            ),
+            patch(
+                "custom_components.pawcontrol.installation_manager.async_remove_helpers_for_dog",
+                remove_mock,
+            ),
         ):
             result = await manager.unload_entry(hass, entry)
 
         unload_mock.assert_called_once_with(hass, entry)
+        remove_mock.assert_called_once_with(hass, "Fido")
         assert result is True
 
     import asyncio

--- a/tests/test_setup_helpers.py
+++ b/tests/test_setup_helpers.py
@@ -1,0 +1,56 @@
+import os
+import sys
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+# Ensure custom component package is importable
+sys.path.insert(0, os.path.abspath("."))
+
+from custom_components.pawcontrol.setup_helpers import (
+    async_create_helpers_for_dog,
+    async_remove_helpers_for_dog,
+)
+
+
+def test_create_helpers_invokes_services():
+    async def run_test() -> None:
+        hass = object()
+        with patch(
+            "custom_components.pawcontrol.setup_helpers.safe_service_call",
+            AsyncMock(),
+        ) as mock_call:
+            await async_create_helpers_for_dog(hass, "rex")
+        called_entities = {c.args[3]["entity_id"] for c in mock_call.await_args_list}
+        assert mock_call.await_count == 6
+        assert called_entities == {
+            "input_datetime.last_walk_rex",
+            "input_boolean.visitor_mode_rex",
+            "input_text.last_activity_rex",
+            "counter.feeding_rex",
+            "counter.walk_rex",
+            "counter.potty_rex",
+        }
+
+    asyncio.run(run_test())
+
+
+def test_remove_helpers_invokes_services():
+    async def run_test() -> None:
+        hass = object()
+        with patch(
+            "custom_components.pawcontrol.setup_helpers.safe_service_call",
+            AsyncMock(),
+        ) as mock_call:
+            await async_remove_helpers_for_dog(hass, "rex")
+        called_entities = {c.args[3]["entity_id"] for c in mock_call.await_args_list}
+        assert mock_call.await_count == 6
+        assert called_entities == {
+            "input_datetime.last_walk_rex",
+            "input_boolean.visitor_mode_rex",
+            "input_text.last_activity_rex",
+            "counter.feeding_rex",
+            "counter.walk_rex",
+            "counter.potty_rex",
+        }
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- warn when YAML configuration is used and support reloading entries
- allow helper entities to be removed and clean them up when unloading
- add tests for helper utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893bd23d3d48331a0e3b0b8c17f4880