### PR TITLE
refactor: expose domain data helpers

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Dict, Optional
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -13,33 +13,53 @@ from .installation_manager import InstallationManager
 DOMAIN = "pawcontrol"
 
 
-def _get_domain_data(hass: HomeAssistant) -> dict[str, Any]:
-    """Return the storage dictionary for this domain."""
+def get_domain_data(hass: HomeAssistant) -> Dict[str, InstallationManager]:
+    """Return the storage dictionary for this domain.
+
+    The dictionary is created on demand and stored in ``hass.data``.
+    """
     data = getattr(hass, "data", None)
     if data is None:
         data = hass.data = {}
     return data.setdefault(DOMAIN, {})
 
 
+def get_manager(hass: HomeAssistant, entry_id: str) -> Optional[InstallationManager]:
+    """Return the :class:`InstallationManager` for a config entry.
+
+    Returns ``None`` if the entry has not been set up yet.
+    """
+    return get_domain_data(hass).get(entry_id)
+
+
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up the Paw Control integration (YAML not supported)."""
-    _get_domain_data(hass)
+    get_domain_data(hass)
     return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Paw Control from a config entry."""
     manager = InstallationManager()
-    _get_domain_data(hass)[entry.entry_id] = manager
+    get_domain_data(hass)[entry.entry_id] = manager
     return await manager.setup_entry(hass, entry)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a Paw Control config entry."""
-    manager: InstallationManager | None = _get_domain_data(hass).pop(
-        entry.entry_id, None
-    )
+    manager = get_manager(hass, entry.entry_id)
     if manager is None:
         return False
+    get_domain_data(hass).pop(entry.entry_id, None)
     return await manager.unload_entry(hass, entry)
+
+
+__all__ = [
+    "DOMAIN",
+    "async_setup",
+    "async_setup_entry",
+    "async_unload_entry",
+    "get_domain_data",
+    "get_manager",
+]
 

--- a/custom_components/pawcontrol/setup_helpers.py
+++ b/custom_components/pawcontrol/setup_helpers.py
@@ -21,17 +21,23 @@ from .utils import safe_service_call
 
 _LOGGER = logging.getLogger(__name__)
 
+COUNTERS = ("feeding", "walk", "potty")
+
+
+async def _call_service(
+    hass: HomeAssistant, dog_id: str, domain: str, service: str, data: dict
+) -> None:
+    """Execute a helper service call and log errors."""
+    try:
+        await safe_service_call(hass, domain, service, data)
+    except Exception:  # pragma: no cover - defensive programming
+        _LOGGER.exception(
+            "Error creating helper %s for dog %s", data.get("entity_id", "?"), dog_id
+        )
+
 
 async def async_create_helpers_for_dog(hass: HomeAssistant, dog_id: str) -> None:
     """Create helper entities required for core features."""
-
-    async def _svc(domain: str, service: str, data: dict) -> None:
-        try:
-            await safe_service_call(hass, domain, service, data)
-        except Exception:  # pragma: no cover - defensive programming
-            _LOGGER.exception(
-                "Error creating helper %s for dog %s", data.get("entity_id", "?"), dog_id
-            )
 
     helper_calls: list[tuple[str, str, dict]] = [
         (
@@ -64,7 +70,7 @@ async def async_create_helpers_for_dog(hass: HomeAssistant, dog_id: str) -> None
         "step": 1,
         "restore": True,
     }
-    for counter in ["feeding", "walk", "potty"]:
+    for counter in COUNTERS:
         helper_calls.append(
             (
                 COUNTER_DOMAIN,
@@ -74,7 +80,10 @@ async def async_create_helpers_for_dog(hass: HomeAssistant, dog_id: str) -> None
         )
 
     await asyncio.gather(
-        *(_svc(domain, service, data) for domain, service, data in helper_calls)
+        *(
+            _call_service(hass, dog_id, domain, service, data)
+            for domain, service, data in helper_calls
+        )
     )
 
 

--- a/custom_components/pawcontrol/setup_verifier.py
+++ b/custom_components/pawcontrol/setup_verifier.py
@@ -591,3 +591,13 @@ async def async_cleanup_duplicate_entities(hass: HomeAssistant, dog_name: str) -
             **cleanup_result,
             "error": str(e)
         }
+
+
+__all__ = [
+    "CriticalEntityReport",
+    "RepairResult",
+    "async_verify_critical_entities",
+    "async_repair_broken_entities",
+    "async_generate_installation_report",
+    "async_cleanup_duplicate_entities",
+]

--- a/tests/test_domain_data.py
+++ b/tests/test_domain_data.py
@@ -1,0 +1,43 @@
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+sys.path.insert(0, os.path.abspath("."))
+
+import custom_components.pawcontrol as integration
+from custom_components.pawcontrol.const import DOMAIN
+from custom_components.pawcontrol.installation_manager import InstallationManager
+from homeassistant import config_entries
+
+
+def test_manager_lifecycle(monkeypatch):
+    async def run_test():
+        entry = config_entries.ConfigEntry(
+            version=1,
+            minor_version=1,
+            domain=DOMAIN,
+            title="Fido",
+            data={},
+            source="user",
+        )
+
+        hass = SimpleNamespace()
+
+        setup_mock = AsyncMock(return_value=True)
+        unload_mock = AsyncMock(return_value=True)
+        monkeypatch.setattr(InstallationManager, "setup_entry", setup_mock)
+        monkeypatch.setattr(InstallationManager, "unload_entry", unload_mock)
+
+        await integration.async_setup_entry(hass, entry)
+        manager = integration.get_manager(hass, entry.entry_id)
+        assert isinstance(manager, InstallationManager)
+
+        await integration.async_unload_entry(hass, entry)
+        assert integration.get_manager(hass, entry.entry_id) is None
+        assert entry.entry_id not in integration.get_domain_data(hass)
+        setup_mock.assert_awaited_once_with(hass, entry)
+        unload_mock.assert_awaited_once_with(hass, entry)
+
+    import asyncio
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- expose domain data storage and manager lookup helpers
- streamline helper creation logic and add explicit module exports
- cover manager lifecycle with a dedicated test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893bd23d3d48331a0e3b0b8c17f4880