### PR TITLE
refactor: enhance core setup modules

### DIFF
--- a/custom_components/pawcontrol/installation_manager.py
+++ b/custom_components/pawcontrol/installation_manager.py
@@ -61,3 +61,6 @@ class InstallationManager:
                 _LOGGER.exception("Error creating dashboard for %s", dog_name)
         else:
             _LOGGER.warning("Dashboard creation requested but no dog name provided")
+
+
+__all__ = ["InstallationManager"]

--- a/custom_components/pawcontrol/module_registry.py
+++ b/custom_components/pawcontrol/module_registry.py
@@ -177,6 +177,8 @@ async_unload_modules = unload_modules
 __all__ = [
     "MODULES",
     "Module",
+    "enabled_modules",
+    "disabled_modules",
     "async_ensure_helpers",
     "async_setup_modules",
     "async_unload_modules",

--- a/custom_components/pawcontrol/service_handlers.py
+++ b/custom_components/pawcontrol/service_handlers.py
@@ -547,6 +547,20 @@ async def end_walk_tracking(hass: HomeAssistant, dog_name: str, data: dict) -> N
 
 
 SERVICE_HANDLERS = {
+    "update_feeding_entities": update_feeding_entities,
+    "update_walk_start_entities": update_walk_start_entities,
+    "update_walk_end_entities": update_walk_end_entities,
+    "update_health_entities": update_health_entities,
+    "update_mood_entities": update_mood_entities,
+    "update_training_start_entities": update_training_start_entities,
+    "update_training_end_entities": update_training_end_entities,
+    "update_medication_entities": update_medication_entities,
+    "update_vet_entities": update_vet_entities,
+    "update_playtime_start_entities": update_playtime_start_entities,
+    "update_playtime_end_entities": update_playtime_end_entities,
+    "reset_all_entities": reset_all_entities,
+    "update_gps_entities": update_gps_entities,
+    "setup_gps_automation": setup_gps_automation,
     "start_walk_tracking": start_walk_tracking,
     "end_walk_tracking": end_walk_tracking,
 }

--- a/custom_components/pawcontrol/services.yaml
+++ b/custom_components/pawcontrol/services.yaml
@@ -7,7 +7,6 @@ feed_dog:
       required: true
       selector:
         text:
-
     meal_type:
       description: Art der Mahlzeit
       example: "morning"
@@ -30,28 +29,8 @@ feed_dog:
           step: 10
           unit_of_measurement: "g"
 
-start_walk:
-  description: Startet einen neuen Spaziergang.
-  fields:
-    dog_name:
-      description: Name des Hundes
-      example: "buddy"
-      required: true
-      selector:
-        text:
-    walk_type:
-      description: Art des Spaziergangs
-      example: "normal"
-      default: "normal"
-      selector:
-        select:
-          options:
-            - "short"
-            - "normal"
-            - "long"
-
-end_walk:
-  description: Beendet den aktuellen Spaziergang.
+walk_dog:
+  description: Zeichnet einen Spaziergang auf.
   fields:
     dog_name:
       description: Name des Hundes
@@ -69,6 +48,250 @@ end_walk:
           max: 300
           step: 1
           unit_of_measurement: "min"
+    distance:
+      description: Zurückgelegte Distanz in Kilometern
+      example: "2.5"
+      selector:
+        text:
+    notes:
+      description: Notizen zum Spaziergang
+      selector:
+        text:
+          multiline: true
+    weather:
+      description: Wetterbedingungen
+      selector:
+        text:
+
+play_with_dog:
+  description: Zeichnet eine Spielsession auf.
+  fields:
+    dog_name:
+      description: Name des Hundes
+      example: "buddy"
+      required: true
+      selector:
+        text:
+    duration:
+      description: Dauer des Spielens in Minuten
+      example: 15
+      default: 15
+      selector:
+        number:
+          min: 1
+          max: 300
+          step: 1
+          unit_of_measurement: "min"
+    play_type:
+      description: Art des Spiels
+      selector:
+        text:
+    intensity:
+      description: Intensität der Session
+      selector:
+        text:
+    notes:
+      description: Notizen
+      selector:
+        text:
+          multiline: true
+
+activate_emergency_mode:
+  description: Aktiviert den Notfallmodus.
+  fields:
+    dog_name:
+      description: Name des Hundes
+      example: "buddy"
+      required: true
+      selector:
+        text:
+    reason:
+      description: Grund für den Notfallmodus
+      selector:
+        text:
+          multiline: true
+
+toggle_visitor_mode:
+  description: Schaltet den Besuchermodus um.
+  fields:
+    dog_name:
+      description: Name des Hundes
+      example: "buddy"
+      required: true
+      selector:
+        text:
+
+perform_health_check:
+  description: Führt einen Gesundheitscheck durch.
+  fields:
+    dog_name:
+      description: Name des Hundes
+      example: "buddy"
+      required: true
+      selector:
+        text:
+    temperature:
+      description: Körpertemperatur in °C
+      example: 38.5
+      selector:
+        number:
+          min: 35.0
+          max: 42.0
+          step: 0.1
+          unit_of_measurement: "°C"
+    weight:
+      description: Aktuelles Gewicht in kg
+      example: 25.5
+      selector:
+        number:
+          min: 0.5
+          max: 100.0
+          step: 0.1
+          unit_of_measurement: "kg"
+    notes:
+      description: Gesundheitsnotizen
+      example: "Allgemein guter Zustand"
+      selector:
+        text:
+          multiline: true
+
+mark_medication_given:
+  description: Markiert Medikamente als gegeben.
+  fields:
+    dog_name:
+      description: Name des Hundes
+      example: "buddy"
+      required: true
+      selector:
+        text:
+    medication:
+      description: Name des Medikaments
+      selector:
+        text:
+    dosage:
+      description: Dosierung
+      selector:
+        text:
+    notes:
+      description: Notizen
+      selector:
+        text:
+          multiline: true
+
+start_grooming_session:
+  description: Zeichnet eine Pflegesession auf.
+  fields:
+    dog_name:
+      description: Name des Hundes
+      example: "buddy"
+      required: true
+      selector:
+        text:
+    grooming_type:
+      description: Art der Pflege
+      selector:
+        text:
+    duration:
+      description: Dauer in Minuten
+      example: 30
+      default: 30
+      selector:
+        number:
+          min: 1
+          max: 300
+          step: 1
+          unit_of_measurement: "min"
+    professional:
+      description: Wird professionell durchgeführt
+      selector:
+        boolean:
+    notes:
+      description: Notizen
+      selector:
+        text:
+          multiline: true
+
+start_training_session:
+  description: Zeichnet eine Trainingseinheit auf.
+  fields:
+    dog_name:
+      description: Name des Hundes
+      example: "buddy"
+      required: true
+      selector:
+        text:
+    training_type:
+      description: Art des Trainings
+      selector:
+        text:
+    duration:
+      description: Dauer in Minuten
+      example: 10
+      default: 10
+      selector:
+        number:
+          min: 1
+          max: 300
+          step: 1
+          unit_of_measurement: "min"
+    commands:
+      description: Geübte Kommandos
+      selector:
+        text:
+    success_rate:
+      description: Erfolgsquote
+      selector:
+        text:
+    notes:
+      description: Notizen
+      selector:
+        text:
+          multiline: true
+
+record_vet_visit:
+  description: Protokolliert einen Tierarztbesuch.
+  fields:
+    dog_name:
+      description: Name des Hundes
+      example: "buddy"
+      required: true
+      selector:
+        text:
+    visit_type:
+      description: Art des Besuchs
+      selector:
+        text:
+    diagnosis:
+      description: Diagnose
+      selector:
+        text:
+    treatment:
+      description: Behandlung
+      selector:
+        text:
+    next_appointment:
+      description: Nächster Termin
+      selector:
+        text:
+    cost:
+      description: Kosten
+      selector:
+        text:
+    notes:
+      description: Notizen
+      selector:
+        text:
+          multiline: true
+
+generate_report:
+  description: Generiert einen Installationsbericht.
+  fields:
+    dog_name:
+      description: Name des Hundes
+      example: "buddy"
+      required: true
+      selector:
+        text:
 
 update_gps:
   description: Aktualisiert die GPS-Position des Hundes.
@@ -107,40 +330,6 @@ update_gps:
           max: 1000
           step: 1
           unit_of_measurement: "m"
-
-health_check:
-  description: Führt einen Gesundheitscheck durch.
-  fields:
-    dog_name:
-      description: Name des Hundes
-      example: "buddy"
-      required: true
-      selector:
-        text:
-    temperature:
-      description: Körpertemperatur in °C
-      example: 38.5
-      selector:
-        number:
-          min: 35.0
-          max: 42.0
-          step: 0.1
-          unit_of_measurement: "°C"
-    weight:
-      description: Aktuelles Gewicht in kg
-      example: 25.5
-      selector:
-        number:
-          min: 0.5
-          max: 100.0
-          step: 0.1
-          unit_of_measurement: "kg"
-    notes:
-      description: Gesundheitsnotizen
-      example: "Allgemein guter Zustand"
-      selector:
-        text:
-          multiline: true
 
 daily_reset:
   description: Setzt alle täglichen Daten zurück.

--- a/custom_components/pawcontrol/setup_helpers.py
+++ b/custom_components/pawcontrol/setup_helpers.py
@@ -22,6 +22,15 @@ from .utils import safe_service_call
 _LOGGER = logging.getLogger(__name__)
 
 
+COUNTER_CONFIG = {
+    "initial": 0,
+    "minimum": 0,
+    "maximum": 20,
+    "step": 1,
+    "restore": True,
+}
+
+
 async def async_create_helpers_for_dog(hass: HomeAssistant, dog_id: str) -> None:
     """Create helper entities required for core features."""
 
@@ -57,19 +66,12 @@ async def async_create_helpers_for_dog(hass: HomeAssistant, dog_id: str) -> None
         ),
     ]
 
-    counter_cfg = {
-        "initial": 0,
-        "minimum": 0,
-        "maximum": 20,
-        "step": 1,
-        "restore": True,
-    }
     for counter in ["feeding", "walk", "potty"]:
         helper_calls.append(
             (
                 COUNTER_DOMAIN,
                 "configure",
-                {"entity_id": f"counter.{counter}_{dog_id}", **counter_cfg},
+                {"entity_id": f"counter.{counter}_{dog_id}", **COUNTER_CONFIG},
             )
         )
 

--- a/custom_components/pawcontrol/setup_verifier.py
+++ b/custom_components/pawcontrol/setup_verifier.py
@@ -9,7 +9,6 @@ from datetime import datetime
 from typing import Any, Dict
 
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
 
 from .utils import safe_service_call
 
@@ -589,5 +588,14 @@ async def async_cleanup_duplicate_entities(hass: HomeAssistant, dog_name: str) -
         _LOGGER.error("Error during duplicate cleanup: %s", e)
         return {
             **cleanup_result,
-            "error": str(e)
+            "error": str(e),
         }
+
+
+__all__ = [
+    "async_verify_critical_entities",
+    "async_repair_broken_entities",
+    "async_generate_installation_report",
+    "async_verify_and_fix_installation",
+    "async_cleanup_duplicate_entities",
+]


### PR DESCRIPTION
## Summary
- export module registries and extend service handler coverage
- add helper utilities for notifications, notes, and helper creation
- expand Home Assistant service descriptions
- fix script system export declaration placement

## Testing
- `pytest`
- `pre-commit run --files custom_components/pawcontrol/script_system.py` *(command failed: pre-commit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893bc0147a88331bcb463c50fb54126