### PR TITLE
Refactor validation and add service data checks

### DIFF
--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -1,27 +1,28 @@
 """Utility functions for Paw Control integration."""
+
 from __future__ import annotations
 
-import re
 import logging
+import re
 from datetime import datetime, timedelta, timezone
-from math import radians, sin, cos, sqrt, atan2, isfinite
-from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
+from math import atan2, cos, isfinite, radians, sin, sqrt
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Tuple
 
-from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
 from homeassistant.util import slugify
 
 from .const import (
-    MIN_DOG_NAME_LENGTH,
-    MAX_DOG_NAME_LENGTH,
-    MIN_DOG_AGE,
-    MAX_DOG_AGE,
     DOG_NAME_PATTERN,
     GPS_ACCURACY_THRESHOLDS,
+    MAX_DOG_AGE,
+    MAX_DOG_NAME_LENGTH,
+    MIN_DOG_AGE,
+    MIN_DOG_NAME_LENGTH,
     VALIDATION_RULES,
 )
-from .exceptions import InvalidCoordinates, DataValidationError
+from .exceptions import DataValidationError, InvalidCoordinates
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -130,26 +131,30 @@ def validate_gps_accuracy(accuracy: float) -> bool:
         return False
 
 
-def calculate_distance(coord1: Tuple[float, float], coord2: Tuple[float, float]) -> float:
+def calculate_distance(
+    coord1: Tuple[float, float], coord2: Tuple[float, float]
+) -> float:
     """Calculate distance between two GPS coordinates in meters using Haversine formula."""
-    if not validate_coordinates(coord1[0], coord1[1]) or not validate_coordinates(coord2[0], coord2[1]):
+    if not validate_coordinates(coord1[0], coord1[1]) or not validate_coordinates(
+        coord2[0], coord2[1]
+    ):
         raise InvalidCoordinates("Invalid GPS coordinates provided")
-    
+
     lat1, lon1 = coord1
     lat2, lon2 = coord2
-    
+
     # Convert to radians
     lat1, lon1, lat2, lon2 = map(radians, [lat1, lon1, lat2, lon2])
-    
+
     # Haversine formula
     dlat = lat2 - lat1
     dlon = lon2 - lon1
-    a = sin(dlat/2)**2 + cos(lat1) * cos(lat2) * sin(dlon/2)**2
-    c = 2 * atan2(sqrt(a), sqrt(1-a))
-    
+    a = sin(dlat / 2) ** 2 + cos(lat1) * cos(lat2) * sin(dlon / 2) ** 2
+    c = 2 * atan2(sqrt(a), sqrt(1 - a))
+
     # Earth's radius in meters
     r = 6371000
-    
+
     return r * c
 
 
@@ -213,7 +218,9 @@ def get_gps_accuracy_level(accuracy: float) -> str:
         return "Schlecht"
 
 
-def calculate_dog_calories_per_day(weight_kg: float, activity_level: str = "normal") -> int:
+def calculate_dog_calories_per_day(
+    weight_kg: float, activity_level: str = "normal"
+) -> int:
     """Calculate daily calorie needs for a dog based on weight and activity level."""
     # Validate weight to avoid math errors with invalid or negative values
     if not validate_weight(weight_kg):
@@ -222,7 +229,7 @@ def calculate_dog_calories_per_day(weight_kg: float, activity_level: str = "norm
     weight = float(weight_kg)
 
     # Base formula: RER = 70 * (weight in kg)^0.75
-    rer = 70 * (weight ** 0.75)
+    rer = 70 * (weight**0.75)
 
     # Activity multipliers
     multipliers = {
@@ -237,11 +244,13 @@ def calculate_dog_calories_per_day(weight_kg: float, activity_level: str = "norm
     return int(rer * multiplier)
 
 
-def calculate_ideal_walk_duration(weight_kg: float, age_years: float, activity_level: str = "normal") -> int:
+def calculate_ideal_walk_duration(
+    weight_kg: float, age_years: float, activity_level: str = "normal"
+) -> int:
     """Calculate ideal daily walk duration in minutes."""
     # Base time per kg (adult dog)
     base_minutes_per_kg = 2
-    
+
     # Age adjustments
     if age_years < 1:  # Puppy
         age_multiplier = 0.5
@@ -249,36 +258,42 @@ def calculate_ideal_walk_duration(weight_kg: float, age_years: float, activity_l
         age_multiplier = 0.7
     else:  # Adult
         age_multiplier = 1.0
-    
+
     # Activity level adjustments
     activity_multipliers = {
         "very_low": 0.5,
         "low": 0.7,
         "normal": 1.0,
         "high": 1.3,
-        "very_high": 1.5
+        "very_high": 1.5,
     }
-    
+
     activity_multiplier = activity_multipliers.get(activity_level, 1.0)
-    
+
     # Calculate
     base_time = weight_kg * base_minutes_per_kg
     adjusted_time = base_time * age_multiplier * activity_multiplier
-    
+
     # Reasonable bounds
     return max(15, min(180, int(adjusted_time)))
 
 
-def validate_service_data(data: Dict[str, Any], required_fields: List[str]) -> bool:
-    """Validate service call data."""
-    if not isinstance(data, dict):
-        return False
-    
-    for field in required_fields:
-        if field not in data:
-            return False
-    
-    return True
+def validate_service_data(
+    data: Mapping[str, Any], required_fields: Iterable[str]
+) -> None:
+    """Validate service call data.
+
+    Raises
+    ------
+    DataValidationError
+        If ``data`` is not a mapping or required fields are missing.
+    """
+    if not isinstance(data, Mapping):
+        raise DataValidationError("Service data must be a mapping")
+
+    missing = [field for field in required_fields if field not in data]
+    if missing:
+        raise DataValidationError(f"Missing required field(s): {', '.join(missing)}")
 
 
 def safe_float_convert(value: Any, default: float = 0.0) -> float:
@@ -358,22 +373,19 @@ def calculate_speed_kmh(distance_m: float, time_seconds: float) -> float:
     return round(speed_kmh, 1)
 
 
-def estimate_calories_burned(distance_km: float, weight_kg: float, activity_intensity: str = "medium") -> int:
+def estimate_calories_burned(
+    distance_km: float, weight_kg: float, activity_intensity: str = "medium"
+) -> int:
     """Estimate calories burned during activity."""
     # Base calories per km per kg
     base_cal_per_km_per_kg = 0.8
-    
+
     # Intensity multipliers
-    intensity_multipliers = {
-        "low": 0.7,
-        "medium": 1.0,
-        "high": 1.4,
-        "extreme": 1.8
-    }
-    
+    intensity_multipliers = {"low": 0.7, "medium": 1.0, "high": 1.4, "extreme": 1.8}
+
     multiplier = intensity_multipliers.get(activity_intensity, 1.0)
     calories = distance_km * weight_kg * base_cal_per_km_per_kg * multiplier
-    
+
     return max(1, int(calories))
 
 
@@ -391,7 +403,9 @@ def time_since_last_activity(last_activity_time: str | datetime) -> timedelta:
         if isinstance(last_activity_time, datetime):
             last_time = last_activity_time
         else:
-            last_time = datetime.fromisoformat(str(last_activity_time).replace("Z", "+00:00"))
+            last_time = datetime.fromisoformat(
+                str(last_activity_time).replace("Z", "+00:00")
+            )
 
         if last_time.tzinfo:
             now = datetime.now(timezone.utc)
@@ -421,34 +435,38 @@ def get_activity_status_emoji(activity_type: str, completed: bool) -> str:
         "health": "🏥",
         "grooming": "✂️",
         "medication": "💊",
-        "vet": "🩺"
+        "vet": "🩺",
     }
-    
+
     emoji = activity_emojis.get(activity_type, "📝")
     status = "✅" if completed else "⏳"
-    
+
     return f"{emoji} {status}"
 
 
 def validate_data_against_rules(data: Dict[str, Any]) -> List[str]:
     """Validate data against defined validation rules."""
     errors = []
-    
+
     for field, value in data.items():
         if field in VALIDATION_RULES:
             rule = VALIDATION_RULES[field]
-            
+
             try:
                 num_value = float(value)
-                
+
                 if num_value < rule["min"]:
-                    errors.append(f"{field} must be at least {rule['min']} {rule['unit']}")
+                    errors.append(
+                        f"{field} must be at least {rule['min']} {rule['unit']}"
+                    )
                 elif num_value > rule["max"]:
-                    errors.append(f"{field} must be at most {rule['max']} {rule['unit']}")
-                    
+                    errors.append(
+                        f"{field} must be at most {rule['max']} {rule['unit']}"
+                    )
+
             except (ValueError, TypeError):
                 errors.append(f"{field} must be a valid number")
-    
+
     return errors
 
 
@@ -463,7 +481,7 @@ def normalize_dog_name(name: str) -> str:
     """Normalize dog name for consistent use."""
     if not name:
         return ""
-    
+
     # Remove extra whitespace and convert to title case
     normalized = " ".join(name.strip().split())
     return normalized.title()
@@ -481,7 +499,9 @@ def get_meal_time_category(hour: int) -> str:
         return "snack"
 
 
-def calculate_dog_age_in_human_years(dog_age_years: float, size_category: str = "medium") -> int:
+def calculate_dog_age_in_human_years(
+    dog_age_years: float, size_category: str = "medium"
+) -> int:
     """Calculate dog age in human equivalent years."""
     # Different aging rates by size
     if dog_age_years <= 2:
@@ -494,12 +514,12 @@ def calculate_dog_age_in_human_years(dog_age_years: float, size_category: str = 
             "small": 4.5,
             "medium": 5,
             "large": 5.5,
-            "giant": 6
+            "giant": 6,
         }
-        
+
         multiplier = size_multipliers.get(size_category, 5)
         human_years = 21 + (dog_age_years - 2) * multiplier
-    
+
     return int(human_years)
 
 
@@ -510,34 +530,36 @@ def is_healthy_weight_for_breed(weight_kg: float, breed_size: str) -> bool:
         "small": (6, 12),
         "medium": (12, 27),
         "large": (27, 45),
-        "giant": (45, 90)
+        "giant": (45, 90),
     }
-    
+
     if breed_size not in weight_ranges:
         return True  # Unknown breed, assume healthy
-    
+
     min_weight, max_weight = weight_ranges[breed_size]
     return min_weight <= weight_kg <= max_weight
 
 
-async def safe_service_call(hass: HomeAssistant, domain: str, service: str, data: dict) -> bool:
+async def safe_service_call(
+    hass: HomeAssistant, domain: str, service: str, data: dict
+) -> bool:
     """Make a safe service call with error handling."""
     try:
         entity_id = data.get("entity_id")
-        
+
         # Check if service exists
         if not hass.services.has_service(domain, service):
             _LOGGER.debug("Service %s.%s not available", domain, service)
             return False
-        
+
         # Check if entity exists (if specified)
         if entity_id and not hass.states.get(entity_id):
             _LOGGER.debug("Entity %s not found, skipping service call", entity_id)
             return False
-        
+
         await hass.services.async_call(domain, service, data, blocking=True)
         return True
-        
+
     except Exception as e:
         _LOGGER.debug("Service call %s.%s failed: %s", domain, service, e)
         return False
@@ -548,11 +570,11 @@ def extract_dog_name_from_entity_id(entity_id: str) -> str:
     try:
         # Remove domain prefix
         entity_name = entity_id.split(".", 1)[1] if "." in entity_id else entity_id
-        
+
         # Extract dog name (first part before underscore)
         parts = entity_name.split("_")
         return parts[0] if parts else entity_name
-        
+
     except (IndexError, AttributeError):
         return ""
 
@@ -568,7 +590,7 @@ def format_time_ago(dt: datetime) -> str:
     """Format datetime as 'time ago' string."""
     now = datetime.now()
     diff = now - dt
-    
+
     if diff.days > 0:
         return f"vor {diff.days} Tag{'en' if diff.days > 1 else ''}"
     elif diff.seconds >= 3600:
@@ -590,9 +612,9 @@ def get_health_status_color(status: str) -> str:
         "normal": "blue",
         "unwohl": "orange",
         "krank": "red",
-        "notfall": "darkred"
+        "notfall": "darkred",
     }
-    
+
     return status_colors.get(status.lower(), "gray")
 
 
@@ -623,10 +645,10 @@ def is_emergency_situation(health_data: Dict[str, Any]) -> bool:
     emergency_indicators = [
         health_data.get("temperature", 0) > 41.0,  # High fever
         health_data.get("temperature", 0) < 37.0,  # Hypothermia
-        health_data.get("heart_rate", 0) > 180,    # Tachycardia
-        health_data.get("heart_rate", 0) < 50,     # Bradycardia
+        health_data.get("heart_rate", 0) > 180,  # Tachycardia
+        health_data.get("heart_rate", 0) < 50,  # Bradycardia
         "notfall" in str(health_data.get("health_status", "")).lower(),
-        "emergency" in str(health_data.get("emergency_mode", "")).lower()
+        "emergency" in str(health_data.get("emergency_mode", "")).lower(),
     ]
-    
+
     return any(emergency_indicators)


### PR DESCRIPTION
## Summary
- switch installation validator to logging output and safer file handling
- add explicit service data validation helper
- cover validation helper with tests
- drop unused call_service import from tests

## Testing
- `pytest`
- `pre-commit run --files tests/test_utils.py` *(fails: command not found; attempted installation but package could not be retrieved)*

------
https://chatgpt.com/codex/tasks/task_e_6893bb6bbaec833198c53c06f04b1743