### PR TITLE
Add happiness sensor

### DIFF
--- a/custom_components/pawcontrol/sensor.py
+++ b/custom_components/pawcontrol/sensor.py
@@ -34,6 +34,7 @@ async def async_setup_entry(
         PawControlWeightSensor(coordinator, dog_name),
         PawControlHealthStatusSensor(coordinator, dog_name),
         PawControlLocationSensor(coordinator, dog_name),
+        PawControlHappinessSensor(coordinator, dog_name),
         PawControlGPSSignalSensor(coordinator, dog_name),
     ]
     
@@ -268,3 +269,23 @@ class PawControlGPSSignalSensor(PawControlSensorEntity):
         
         location = self.coordinator.data.get("location_status", {})
         return location.get("gps_signal", 0)
+
+
+class PawControlHappinessSensor(PawControlSensorEntity):
+    """Sensor for overall happiness of the dog."""
+
+    def __init__(self, coordinator: PawControlCoordinator, dog_name: str) -> None:
+        """Initialize the sensor."""
+        super().__init__(
+            coordinator,
+            dog_name=dog_name,
+            key="happiness_status",
+            icon=get_icon("mood"),
+        )
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the state of the sensor."""
+        if not self.coordinator.data:
+            return "Unknown"
+        return self.coordinator.data.get("happiness_status", "Unknown")

--- a/tests/test_feeding_status.py
+++ b/tests/test_feeding_status.py
@@ -1,0 +1,44 @@
+import asyncio
+
+from custom_components.pawcontrol.coordinator import PawControlCoordinator
+
+
+class DummyState:
+    def __init__(self, state):
+        self.state = state
+
+
+class DummyStates:
+    def __init__(self, states):
+        self._states = states
+
+    def get(self, entity_id):
+        return self._states.get(entity_id)
+
+
+class DummyHass:
+    def __init__(self, states):
+        self.states = DummyStates(states)
+
+
+def make_coordinator(morning="off", evening="off"):
+    coordinator = PawControlCoordinator.__new__(PawControlCoordinator)
+    coordinator.hass = DummyHass(
+        {
+            f"input_boolean.Bello_feeding_morning": DummyState(morning),
+            f"input_boolean.Bello_feeding_evening": DummyState(evening),
+        }
+    )
+    coordinator.dog_name = "Bello"
+    return coordinator
+
+
+def test_needs_feeding_logic():
+    status = asyncio.run(make_coordinator("on", "off")._get_feeding_status())
+    assert status["needs_feeding"]
+
+    status = asyncio.run(make_coordinator("on", "on")._get_feeding_status())
+    assert not status["needs_feeding"]
+
+    status = asyncio.run(make_coordinator("off", "off")._get_feeding_status())
+    assert status["needs_feeding"]

--- a/tests/test_happiness_sensor.py
+++ b/tests/test_happiness_sensor.py
@@ -1,0 +1,38 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("."))
+
+from custom_components.pawcontrol.coordinator import PawControlCoordinator
+from custom_components.pawcontrol.sensor import PawControlHappinessSensor
+
+
+class DummyCoordinator:
+    def __init__(self, data=None):
+        self.data = data or {}
+
+
+def test_happiness_sensor_reads_state():
+    coordinator = DummyCoordinator({"happiness_status": "Happy"})
+    sensor = PawControlHappinessSensor(coordinator, "Bello")
+    assert sensor.native_value == "Happy"
+
+    coordinator.data["happiness_status"] = "Needs attention"
+    assert sensor.native_value == "Needs attention"
+
+
+def test_calculate_happiness_logic():
+    coordinator = PawControlCoordinator.__new__(PawControlCoordinator)
+    data = {
+        "feeding_status": {"morning_fed": True, "evening_fed": True},
+        "activity_status": {"walked_today": True},
+    }
+    assert coordinator._calculate_happiness(data) == "Happy"
+
+    data["feeding_status"]["evening_fed"] = False
+    assert coordinator._calculate_happiness(data) == "Needs attention"
+
+    data["feeding_status"]["evening_fed"] = True
+    data["activity_status"]["walked_today"] = False
+    assert coordinator._calculate_happiness(data) == "Needs attention"
+


### PR DESCRIPTION
## Summary
- compute a basic happiness metric based on feeding and walking
- expose a new happiness sensor via the sensor platform
- cover happiness logic with unit tests
- fix feeding status to consider both morning and evening feedings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893be15a7c483318cc76fbc0dde1bdd