### PR TITLE
Refine setup utilities and fix initialization errors

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -1,10 +1,9 @@
-"""Paw Control integration setup and teardown."""
+"""Paw Control integration setup and helpers."""
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
-
 import logging
+from typing import Dict, Optional
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -13,16 +12,11 @@ from .actionable_push import setup_actionable_notifications
 from .const import DOMAIN
 from .installation_manager import InstallationManager
 
-DOMAIN = "pawcontrol"
-
 _LOGGER = logging.getLogger(__name__)
 
 
 def get_domain_data(hass: HomeAssistant) -> Dict[str, InstallationManager]:
-    """Return the storage dictionary for this domain.
-
-    The dictionary is created on demand and stored in ``hass.data``.
-    """
+    """Return the storage dictionary for this domain."""
     data = getattr(hass, "data", None)
     if data is None:
         data = hass.data = {}
@@ -30,22 +24,18 @@ def get_domain_data(hass: HomeAssistant) -> Dict[str, InstallationManager]:
 
 
 def get_manager(hass: HomeAssistant, entry_id: str) -> Optional[InstallationManager]:
-    """Return the :class:`InstallationManager` for a config entry.
-
-    Returns ``None`` if the entry has not been set up yet.
-    """
+    """Return the :class:`InstallationManager` for ``entry_id`` if available."""
     return get_domain_data(hass).get(entry_id)
 
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
-    """Set up the Paw Control integration (YAML configuration not supported)."""
-    _get_domain_data(hass)
+    """Set up the Paw Control integration."""
+    get_domain_data(hass)
 
     if DOMAIN in config:
         _LOGGER.warning("Configuration via YAML is not supported")
 
     setup_actionable_notifications(hass)
-
     return True
 
 
@@ -66,8 +56,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Handle reload of a config entry."""
-    await async_unload_entry(hass, entry)
+    """Handle reloading a config entry by unloading and setting it up again."""
+    if not await async_unload_entry(hass, entry):
+        return False
     return await async_setup_entry(hass, entry)
 
 
@@ -80,11 +71,4 @@ __all__ = [
     "get_domain_data",
     "get_manager",
 ]
-
-
-async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Handle reloading a config entry by unloading and setting it up again."""
-    if not await async_unload_entry(hass, entry):
-        return False
-    return await async_setup_entry(hass, entry)
 

--- a/custom_components/pawcontrol/service_handlers.py
+++ b/custom_components/pawcontrol/service_handlers.py
@@ -1,5 +1,7 @@
-"""Service handlers for Paw Control integration."""
+"""Service handler utilities for Paw Control services."""
+
 from __future__ import annotations
+
 import logging
 from datetime import datetime
 from typing import Any

--- a/tests/test_setup_helpers.py
+++ b/tests/test_setup_helpers.py
@@ -12,17 +12,8 @@ from custom_components.pawcontrol.setup_helpers import (
 )
 
 
-def test_create_helpers_invokes_services():
-
-import asyncio
-from unittest.mock import AsyncMock, patch
-
-from custom_components.pawcontrol import setup_helpers
-
-
 def test_async_create_helpers_for_dog_invokes_expected_services():
     """Ensure helper creation issues the correct service calls."""
-
 
     async def run_test() -> None:
         hass = object()
@@ -46,6 +37,8 @@ def test_async_create_helpers_for_dog_invokes_expected_services():
 
 
 def test_remove_helpers_invokes_services():
+    """Ensure helper removal calls expected services."""
+
     async def run_test() -> None:
         hass = object()
         with patch(
@@ -63,18 +56,5 @@ def test_remove_helpers_invokes_services():
             "counter.walk_rex",
             "counter.potty_rex",
         }
-            await setup_helpers.async_create_helpers_for_dog(hass, "rex")
-        # Three base helpers + three counter helpers
-        assert mock_call.await_count == 6
-        domains = [call.args[1] for call in mock_call.await_args_list]
-        services = [call.args[2] for call in mock_call.await_args_list]
-        assert domains.count("input_datetime") == 1
-        assert domains.count("input_boolean") == 1
-        assert domains.count("input_text") == 1
-        assert domains.count("counter") == 3
-        assert "set_datetime" in services
-        assert "turn_off" in services
-        assert "set_value" in services
-        assert services.count("configure") == 3
 
     asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- overhaul helper creation/removal logic and counter configuration
- fix integration setup to use domain data and support reloading
- document service handler module and import requirements
- repair test scaffolding and missing imports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893c7eebae48331afd6bbc6d5ae5697